### PR TITLE
Bug: UpdateItemField with primitive types

### DIFF
--- a/src/Middleware/Drapo/js/DrapoSolver.js
+++ b/src/Middleware/Drapo/js/DrapoSolver.js
@@ -940,7 +940,7 @@ var DrapoSolver = (function () {
     DrapoSolver.prototype.UpdateItemDataPathObject = function (sector, contextItem, executionContext, dataPath, value, canNotify) {
         if (canNotify === void 0) { canNotify = true; }
         return __awaiter(this, void 0, void 0, function () {
-            var key, data, storageItem, item, data;
+            var key, data, storageItem, item;
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
@@ -952,7 +952,7 @@ var DrapoSolver = (function () {
                                 return [2, (true)];
                             return [2, (false)];
                         }
-                        if (!(contextItem === null)) return [3, 4];
+                        if (!(contextItem === null || dataPath.length === 1)) return [3, 4];
                         return [4, this.Application.Storage.RetrieveDataItem(key, sector)];
                     case 1:
                         storageItem = _a.sent();
@@ -979,16 +979,8 @@ var DrapoSolver = (function () {
                         item = _a.sent();
                         if (item == null)
                             return [2, (false)];
-                        if (dataPath.length === 1) {
-                            if (item.Data === value)
-                                return [2, (false)];
-                            item.Data = value;
-                        }
-                        else {
-                            data = item.Data;
-                            if (!this.UpdateDataPathObject(item.Data, dataPath, value))
-                                return [2, (false)];
-                        }
+                        if (!this.UpdateDataPathObject(item.Data, dataPath, value))
+                            return [2, (false)];
                         if (!canNotify) return [3, 7];
                         return [4, this.Application.Observer.Notify(item.DataKey, item.Index, this.ResolveDataFields(dataPath))];
                     case 6:

--- a/src/Middleware/Drapo/lib/drapo.js
+++ b/src/Middleware/Drapo/lib/drapo.js
@@ -21591,7 +21591,7 @@ var DrapoSolver = (function () {
     DrapoSolver.prototype.UpdateItemDataPathObject = function (sector, contextItem, executionContext, dataPath, value, canNotify) {
         if (canNotify === void 0) { canNotify = true; }
         return __awaiter(this, void 0, void 0, function () {
-            var key, data, storageItem, item, data;
+            var key, data, storageItem, item;
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
@@ -21603,7 +21603,7 @@ var DrapoSolver = (function () {
                                 return [2, (true)];
                             return [2, (false)];
                         }
-                        if (!(contextItem === null)) return [3, 4];
+                        if (!(contextItem === null || dataPath.length === 1)) return [3, 4];
                         return [4, this.Application.Storage.RetrieveDataItem(key, sector)];
                     case 1:
                         storageItem = _a.sent();
@@ -21630,16 +21630,8 @@ var DrapoSolver = (function () {
                         item = _a.sent();
                         if (item == null)
                             return [2, (false)];
-                        if (dataPath.length === 1) {
-                            if (item.Data === value)
-                                return [2, (false)];
-                            item.Data = value;
-                        }
-                        else {
-                            data = item.Data;
-                            if (!this.UpdateDataPathObject(item.Data, dataPath, value))
-                                return [2, (false)];
-                        }
+                        if (!this.UpdateDataPathObject(item.Data, dataPath, value))
+                            return [2, (false)];
                         if (!canNotify) return [3, 7];
                         return [4, this.Application.Observer.Notify(item.DataKey, item.Index, this.ResolveDataFields(dataPath))];
                     case 6:

--- a/src/Middleware/Drapo/lib/drapo.min.js
+++ b/src/Middleware/Drapo/lib/drapo.min.js
@@ -21591,7 +21591,7 @@ var DrapoSolver = (function () {
     DrapoSolver.prototype.UpdateItemDataPathObject = function (sector, contextItem, executionContext, dataPath, value, canNotify) {
         if (canNotify === void 0) { canNotify = true; }
         return __awaiter(this, void 0, void 0, function () {
-            var key, data, storageItem, item, data;
+            var key, data, storageItem, item;
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
@@ -21603,7 +21603,7 @@ var DrapoSolver = (function () {
                                 return [2, (true)];
                             return [2, (false)];
                         }
-                        if (!(contextItem === null)) return [3, 4];
+                        if (!(contextItem === null || dataPath.length === 1)) return [3, 4];
                         return [4, this.Application.Storage.RetrieveDataItem(key, sector)];
                     case 1:
                         storageItem = _a.sent();
@@ -21630,16 +21630,8 @@ var DrapoSolver = (function () {
                         item = _a.sent();
                         if (item == null)
                             return [2, (false)];
-                        if (dataPath.length === 1) {
-                            if (item.Data === value)
-                                return [2, (false)];
-                            item.Data = value;
-                        }
-                        else {
-                            data = item.Data;
-                            if (!this.UpdateDataPathObject(item.Data, dataPath, value))
-                                return [2, (false)];
-                        }
+                        if (!this.UpdateDataPathObject(item.Data, dataPath, value))
+                            return [2, (false)];
                         if (!canNotify) return [3, 7];
                         return [4, this.Application.Observer.Notify(item.DataKey, item.Index, this.ResolveDataFields(dataPath))];
                     case 6:

--- a/src/Middleware/Drapo/ts/DrapoSolver.ts
+++ b/src/Middleware/Drapo/ts/DrapoSolver.ts
@@ -744,7 +744,7 @@ class DrapoSolver {
                 return (true);
             return (false);
         }
-        if (contextItem === null) {
+        if (contextItem === null || dataPath.length === 1) {
             //No Context
             const storageItem: DrapoStorageItem = await this.Application.Storage.RetrieveDataItem(key, sector);
             if (storageItem === null)
@@ -765,15 +765,8 @@ class DrapoSolver {
         const item: DrapoContextItem = await this.ResolveDataPathObjectItem(contextItem, key, sector);
         if (item == null)
             return (false);
-        if (dataPath.length === 1) {
-            if (item.Data === value)
-                return (false);
-            item.Data = value;
-        } else {
-            const data: any = item.Data;
-            if (!this.UpdateDataPathObject(item.Data, dataPath, value))
-                return (false);
-        }
+        if (!this.UpdateDataPathObject(item.Data, dataPath, value))
+            return (false);
         if (canNotify)
             await this.Application.Observer.Notify(item.DataKey, item.Index, this.ResolveDataFields(dataPath));
         return (true);

--- a/src/Test/WebDrapo.Test/Pages/FunctionUpdateItemFieldDfor.Test.html
+++ b/src/Test/WebDrapo.Test/Pages/FunctionUpdateItemFieldDfor.Test.html
@@ -1,0 +1,88 @@
+﻿<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <title>Function - UpdateItemField - d-for</title>
+    <script src="/drapo.js"></script>
+</head>
+<body>
+    <h1>Function - UpdateItemField - d-for</h1>
+    <div d-datakey="valueData" d-datatype="value" d-datavalue="Empty"></div>
+    <div d-datakey="objectData" d-datatype="object" d-dataproperty-value="Empty"></div>
+    <div d-datakey="arrayData" d-datatype="array" d-datavalue="[&quot;Empty&quot;,&quot;Empty&quot;,&quot;Empty&quot;]"></div>
+    <div d-datakey="arrayFinalData" d-datatype="array" d-datavalue="[&quot;Wrong1&quot;,&quot;Correct&quot;,&quot;Wrong2&quot;]"></div>
+    <section>
+        <h2>Value dataKey</h2>
+        <p>
+            valueData = <span d-model="{{valueData}}">Correct</span>
+        </p><ul>
+            <li d-for="finalData in arrayFinalData" style="display: none;">
+                <input type="button" d-if="{{finalData}}=Correct" driverunittest="click" d-on-click="UpdateItemField({{valueData}},{{finalData}})" value="Click here to change to '{{finalData}}''" />
+                <input type="button" d-if="{{finalData}}!=Correct" d-on-click="UpdateItemField({{valueData}},{{finalData}})" value="Click here to change to '{{finalData}}'" />
+            </li>
+            <li>
+
+                <input type="button" d-on-click="UpdateItemField({{valueData}},{{finalData}})" value="Click here to change to 'Wrong1'" />
+            </li>
+            <li>
+                <input type="button" driverunittest="click" d-on-click="UpdateItemField({{valueData}},{{finalData}})" value="Click here to change to 'Correct''" />
+
+            </li>
+            <li>
+
+                <input type="button" d-on-click="UpdateItemField({{valueData}},{{finalData}})" value="Click here to change to 'Wrong2'" />
+            </li>
+        </ul>
+        <p></p>
+    </section>
+    <section>
+        <h2>Object dataKey</h2>
+        <p>
+            objectData.value = <span d-model="{{objectData.value}}">Correct</span>
+        </p><ul>
+            <li d-for="finalData in arrayFinalData" style="display: none;">
+                <input type="button" d-if="{{finalData}}=Correct" driverunittest="click" d-on-click="UpdateItemField({{objectData.value}},{{finalData}})" value="Click here to change to '{{finalData}}'" />
+                <input type="button" d-if="{{finalData}}!=Correct" d-on-click="UpdateItemField({{objectData.value}},{{finalData}})" value="Click here to change to '{{finalData}}'" />
+            </li>
+            <li>
+
+                <input type="button" d-on-click="UpdateItemField({{objectData.value}},{{finalData}})" value="Click here to change to 'Wrong1'" />
+            </li>
+            <li>
+                <input type="button" driverunittest="click" d-on-click="UpdateItemField({{objectData.value}},{{finalData}})" value="Click here to change to 'Correct'" />
+
+            </li>
+            <li>
+
+                <input type="button" d-on-click="UpdateItemField({{objectData.value}},{{finalData}})" value="Click here to change to 'Wrong2'" />
+            </li>
+        </ul>
+        <p></p>
+    </section>
+    <section>
+        <h2>Array dataKey</h2>
+        <p>
+            arrayData.[1] = <span d-model="{{arrayData.[1]}}">Correct</span>
+        </p><ul>
+            <li d-for="finalData in arrayFinalData" style="display: none;">
+                <input type="button" d-if="{{finalData}}=Correct" driverunittest="click" d-on-click="UpdateItemField({{arrayData.[1]}},{{finalData}})" value="Click here to change to '{{finalData}}'" />
+                <input type="button" d-if="{{finalData}}!=Correct" d-on-click="UpdateItemField({{arrayData.[1]}},{{finalData}})" value="Click here to change to '{{finalData}}'" />
+            </li>
+            <li>
+
+                <input type="button" d-on-click="UpdateItemField({{arrayData.[1]}},{{finalData}})" value="Click here to change to 'Wrong1'" />
+            </li>
+            <li>
+                <input type="button" driverunittest="click" d-on-click="UpdateItemField({{arrayData.[1]}},{{finalData}})" value="Click here to change to 'Correct'" />
+
+            </li>
+            <li>
+
+                <input type="button" d-on-click="UpdateItemField({{arrayData.[1]}},{{finalData}})" value="Click here to change to 'Wrong2'" />
+            </li>
+        </ul>
+        <p></p>
+    </section>
+    <section id="console"></section>
+
+</body>
+</html>

--- a/src/Test/WebDrapo.Test/ReleaseTest.cs
+++ b/src/Test/WebDrapo.Test/ReleaseTest.cs
@@ -56,7 +56,7 @@ namespace WebDrapo.Test
             if ((elClickUnitTest != null) && (elClickUnitTest.Count > 0))
             {
                 foreach (IWebElement el in elClickUnitTest)
-                    el.Click();
+                    if(el.Displayed) el.Click();
                 System.Threading.Thread.Sleep(5000);
             }
             if (pageName.Contains("Async"))

--- a/src/Test/WebDrapo.Test/ReleaseTest.cs
+++ b/src/Test/WebDrapo.Test/ReleaseTest.cs
@@ -1392,6 +1392,11 @@ namespace WebDrapo.Test
             ValidatePage("FunctionUpdateDataResolve");
         }
         [TestCase]
+        public void FunctionUpdateItemFieldDforTest()
+        {
+            ValidatePage("FunctionUpdateItemFieldDfor");
+        }
+        [TestCase]
         public void FunctionUpdateItemFieldMustacheIndexTest()
         {
             ValidatePage("FunctionUpdateItemFieldMustacheIndex");

--- a/src/Web/WebDrapo/wwwroot/DrapoPages/FunctionUpdateItemFieldDfor.html
+++ b/src/Web/WebDrapo/wwwroot/DrapoPages/FunctionUpdateItemFieldDfor.html
@@ -1,0 +1,51 @@
+﻿<!DOCTYPE html>
+<html>
+<head>
+    <title>Function - UpdateItemField - d-for</title>
+    <script src="/drapo.js"></script>
+</head>
+<body>
+    <h1>Function - UpdateItemField - d-for</h1>
+    <div d-dataKey="valueData" d-dataType="value" d-dataValue="Empty"></div>
+    <div d-dataKey="objectData" d-dataType="object" d-dataProperty-value="Empty"></div>
+    <div d-dataKey="arrayData" d-dataType="array" d-dataValue='["Empty","Empty","Empty"]'></div>
+    <div d-dataKey="arrayFinalData" d-dataType="array" d-dataValue='["Wrong1","Correct","Wrong2"]'></div>
+    <section>
+        <h2>Value dataKey</h2>
+        <p>
+            valueData = <span d-model="{{valueData}}" />
+            <ul>
+                <li d-for="finalData in arrayFinalData">
+                    <input type="button" d-if="{{finalData}}=Correct" driverunittest="click" d-on-click="UpdateItemField({{valueData}},{{finalData}})" value="Click here to change to '{{finalData}}''">
+                    <input type="button" d-if="{{finalData}}!=Correct" d-on-click="UpdateItemField({{valueData}},{{finalData}})" value="Click here to change to '{{finalData}}'">
+                </li>
+            </ul>
+        </p>
+    </section>
+    <section>
+        <h2>Object dataKey</h2>
+        <p>
+            objectData.value = <span d-model="{{objectData.value}}" />
+            <ul>
+                <li d-for="finalData in arrayFinalData">
+                    <input type="button" d-if="{{finalData}}=Correct" driverunittest="click" d-on-click="UpdateItemField({{objectData.value}},{{finalData}})" value="Click here to change to '{{finalData}}'">
+                    <input type="button" d-if="{{finalData}}!=Correct" d-on-click="UpdateItemField({{objectData.value}},{{finalData}})" value="Click here to change to '{{finalData}}'">
+                </li>
+            </ul>
+        </p>
+    </section>
+    <section>
+        <h2>Array dataKey</h2>
+        <p>
+            arrayData.[1] = <span d-model="{{arrayData.[1]}}" />
+            <ul>
+                <li d-for="finalData in arrayFinalData">
+                    <input type="button" d-if="{{finalData}}=Correct" driverunittest="click" d-on-click="UpdateItemField({{arrayData.[1]}},{{finalData}})" value="Click here to change to '{{finalData}}'">
+                    <input type="button" d-if="{{finalData}}!=Correct" d-on-click="UpdateItemField({{arrayData.[1]}},{{finalData}})" value="Click here to change to '{{finalData}}'">
+                </li>
+            </ul>
+        </p>
+    </section>
+    <section id="console"></section>
+</body>
+</html>


### PR DESCRIPTION
Use of UpdateItemField() inside a d-for is not working to update data keys containing primitive data types.
The root cause is that DrapoContextItem keeps a copy of the data inside a DrapoStorageItem, so it can't update the original storage item when the data is a primitive. However it works for reference types.