### PR TITLE
Fix resource keys on DrapoMiddleware initialization.

### DIFF
--- a/src/Middleware/Drapo/DrapoMiddleware.cs
+++ b/src/Middleware/Drapo/DrapoMiddleware.cs
@@ -19,8 +19,8 @@ namespace Sysphera.Middleware.Drapo
         #region Constants
         private const string ACTIVATORJS = "drapo.js";
         private const string ACTIVATORJSON = "drapo.json";
-        private const string LIB_RELEASE = "Sysphera.Middleware.Drapo.lib.drapo.min.js";
-        private const string LIB_DEBUG = "Sysphera.Middleware.Drapo.lib.drapo.js";
+        private const string LIB_RELEASE = "drapo.min.js";
+        private const string LIB_DEBUG = "drapo.js";
         private const string CONTENT_TYPE_HTML = "text/html; charset=utf-8";
         #endregion
         #region Fields


### PR DESCRIPTION
With the recents modifications made to drapo build process, some resource's keys were modified and broke the Drapo Middleware initialization.

LIB_RELEASE was changed of "Sysphera.Middleware.Drapo.lib.drapo.min.js" to "drapo.min.js".
LIB_DEBUG was changed of "Sysphera.Middleware.Drapo.lib.drapo.js" to "drapo.js".

Resolves #498 