### PR TITLE
Include .targets file to copy drapo node_modules

### DIFF
--- a/Package.nuspec
+++ b/Package.nuspec
@@ -11,9 +11,6 @@
     <copyright>Copyright 2017</copyright>
     <tags>Drapo Framework SPA</tags>
     <projectUrl>http://drapo.azurewebsites.net</projectUrl>
-    <contentFiles>
-      <files include="**/*" buildAction="Content" copyToOutput="true" />
-    </contentFiles>
   </metadata>
   <files>
     <file src="src\Middleware\Drapo\bin\Release\netcoreapp3.1\Sysphera.Middleware.Drapo.dll" target="lib\netcoreapp3.1\" />
@@ -21,5 +18,6 @@
     <file src="src\Middleware\Drapo\bin\Release\net8.0\Sysphera.Middleware.Drapo.dll" target="lib\net8.0\" />
     <file src="src\**\*.*" exclude="src\**\*.*" />
     <file src="src\Middleware\Drapo\lib\net8.0\*.d.ts" target="contentFiles\any\any\node_modules\@types\drapo" />
+	<file src="src\Middleware\Drapo\build\**" target="build" />
   </files>
 </package>

--- a/src/Middleware/Drapo/build/drapo.targets
+++ b/src/Middleware/Drapo/build/drapo.targets
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<Target Name="CopyDrapoNodeModule" BeforeTargets="CompileTypeScriptWithTSConfig;BeforeBuild;BeforeRebuild">
+		<ItemGroup>
+			<DrapoNodeModule Include="$(MSBuildThisFileDirectory)..\contentFiles\any\any\node_modules\@types\drapo\index.d.ts" />
+		</ItemGroup>
+		<Copy SourceFiles="@(DrapoNodeModule)" DestinationFolder="node_modules\@types\drapo" />
+	</Target>
+</Project>


### PR DESCRIPTION
With this proposal, any project using Drapo through MSBuild will automatically install Drapo's index.d.ts into node_modules.