### PR TITLE
Dummy JS source map on release builds

### DIFF
--- a/src/Middleware/Drapo/DrapoMiddleware.cs
+++ b/src/Middleware/Drapo/DrapoMiddleware.cs
@@ -275,6 +275,8 @@ namespace Sysphera.Middleware.Drapo
                 }
             }
             string sectionsString = string.Join(',', sections);
+            if (string.IsNullOrEmpty(sectionsString)) //return dummy map
+                return @"{""version"":3,""file"":""drapo.js"",""sourceRoot"":"""",""sources"":[""dummy.ts""],""names"":[],""mappings"":"";AAAA,MAAM""}";
             return $@"{{ ""version"": 3, ""file"": ""drapo.js"", ""sections"": [{sectionsString}] }}";
         }
         #endregion

--- a/src/Middleware/Drapo/DrapoMiddleware.cs
+++ b/src/Middleware/Drapo/DrapoMiddleware.cs
@@ -276,7 +276,7 @@ namespace Sysphera.Middleware.Drapo
             }
             string sectionsString = string.Join(',', sections);
             if (string.IsNullOrEmpty(sectionsString)) //return dummy map
-                return @"{""version"":3,""file"":""drapo.js"",""sourceRoot"":"""",""sources"":[""dummy.ts""],""names"":[],""mappings"":"";AAAA,MAAM""}";
+                return @"{""version"":3,""file"":""drapo.js"",""sourceRoot"":"""",""sources"":[""drapo.js""],""names"":[],""mappings"":""""}";
             return $@"{{ ""version"": 3, ""file"": ""drapo.js"", ""sections"": [{sectionsString}] }}";
         }
         #endregion


### PR DESCRIPTION
Return a dummy drapo.js.map on release builds. This will make the "source maps check" succeed on Lighthouse.