### PR TITLE
Fix the unit test MessageSendValue

### DIFF
--- a/src/Test/WebDrapo.Test/Pages/MessageSendValue.Test.html
+++ b/src/Test/WebDrapo.Test/Pages/MessageSendValue.Test.html
@@ -2,13 +2,13 @@
 	<script src="/drapo.js"></script>
 	<title>Message Send Value</title>
 </head>
-<body>
+<body d-id="__drapoUnitTest">
 	<span>Message Execute</span>
 	<div>
 		<div d-datakey="itemObject" d-datatype="object" d-dataproperty-value-name="Value" d-dataproperty-value-value="OldValue"></div>
 		<div d-datakey="valueFromMessage" d-datatype="value"></div>
 		<div d-datakey="updateItemValue" d-datatype="value" d-datavalue="UpdateDataField(itemObject,Value,{{valueFromMessage}})"></div>
-		<span d-model="{{itemObject.Value}}">NewValue</span>
+		<span d-model="{{itemObject.Value}}" driverunittest="click">NewValue</span>
 		<iframe id="frameID" src="MessageSendValueSector.html"></iframe>
 	</div>
 

--- a/src/Web/WebDrapo/wwwroot/DrapoPages/MessageSendValue.html
+++ b/src/Web/WebDrapo/wwwroot/DrapoPages/MessageSendValue.html
@@ -4,13 +4,13 @@
 	<script src="/drapo.js"></script>
 	<title>Message Send Value</title>
 </head>
-<body>
+<body d-id="__drapoUnitTest">
 	<span>Message Execute</span>
 	<div>
 		<div d-dataKey="itemObject" d-dataType="object" d-dataProperty-value-name="Value" d-dataProperty-value-value="OldValue"></div>
 		<div d-dataKey="valueFromMessage" d-dataType="value"></div>
 		<div d-dataKey="updateItemValue" d-dataType="value" d-dataValue="UpdateDataField(itemObject,Value,{{valueFromMessage}})"></div>
-		<span d-model="{{itemObject.Value}}"></span>
+		<span d-model="{{itemObject.Value}}" driverunittest="click"></span>
 		<iframe id="frameID" src="MessageSendValueSector.html"></iframe>
 	</div>
 </body>

--- a/src/Web/WebDrapo/wwwroot/DrapoPages/MessageSendValueSector.html
+++ b/src/Web/WebDrapo/wwwroot/DrapoPages/MessageSendValueSector.html
@@ -4,7 +4,7 @@
 	<script src="/drapo.js"></script>
 	<title>Message Send Value</title>
 </head>
-<body>
+<body d-id="__drapoUnitTest">
 	<script>
         function ExecuteMessage() {
             var message = {};
@@ -28,7 +28,7 @@
 	</script>
 	<br>
 	<span>Function External Frame Sector</span>
-	<input id="buttonSend" type="button" value="Send" onclick="SendAndExecuteMessage()">
+	<input id="buttonSend" type="button" value="Send" onclick="SendAndExecuteMessage()" driverunittest="click">
 	<script>
         setTimeout(SendAndExecuteMessage,0);
 	</script>


### PR DESCRIPTION
The unit test MessageSendValue started failing after the commit  "start plumber after document is ready (#537)".
This proposal fixes the test by filling the necessary test attributes: d-id="__drapoUnitTest" and driverunittest="click" (for autoclick and making the test framework wait a bit for results)