### PR TITLE
Fix build errors

### DIFF
--- a/src/Middleware/Drapo/Drapo.TypeScript.targets
+++ b/src/Middleware/Drapo/Drapo.TypeScript.targets
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<PropertyGroup>
+		<TypeScriptToolsVersion>Latest</TypeScriptToolsVersion>
+		<TypeScriptCompileBlocked>false</TypeScriptCompileBlocked>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.TypeScript.MSBuild" Version="5.4.5">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<Content Include="tsconfig/development/$(TargetFramework)/tsconfig.json" Condition="'$(Configuration)' == 'Debug'" />
+		<Content Include="tsconfig/production/$(TargetFramework)/tsconfig.json" Condition="'$(Configuration)' == 'Release'" />
+	</ItemGroup>
+
+	<Target Name="FixDeniedAccessOnDelete" BeforeTargets="TypeScriptDeleteOutputFromOtherConfigs" Condition="'$(BuildingProject)' != 'false' AND '$(DesignTimeBuild)' != 'true'">
+		<!-- Messing with the bugged target TypeScriptDeleteOutputFromOtherConfigs from Microsoft.TypeScript.targets and make it do nothing: https://github.com/microsoft/TypeScript/issues/50428 -->
+		<ItemGroup>
+			<TSOutputLogsToDelete Include="$(BaseIntermediateOutputPath)\**\Tsc*.out" />
+			<JsToDelete Include="js\$(TargetFramework)\**\*" />
+		</ItemGroup>
+		<Delete Files="@(JsToDelete)" Condition="'@(JsToDelete)' != '' " />
+		<Delete Files="@(TSOutputLogsToDelete)" Condition="'@(TSOutputLogsToDelete)' != '' " />
+	</Target>
+
+	<Target Name="CleanLibFiles" BeforeTargets="Clean" Condition="'$(DesignTimeBuild)' != 'true'">
+		<ItemGroup>
+			<FilesToDelete Include="lib\$(TargetFramework)\**\*;js\$(TargetFramework)\**\*" />
+		</ItemGroup>
+		<Delete Files="@(FilesToDelete)" />
+	</Target>
+
+	<Target Name="TSLint" BeforeTargets="CompileTypeScriptWithTSConfig" Condition="$(TargetFrameworks.StartsWith($(TargetFramework))) AND '$(BuildingProject)' == 'true' AND '$(DesignTimeBuild)' != 'true'">
+		<Exec Command="npx tslint --project tsconfig/production/tsconfig.base.json" />
+	</Target>
+
+	<Target Name="CreateLibFiles" AfterTargets="CompileTypeScriptWithTSConfig" Condition="'$(BuildingProject)' == 'true' AND '$(DesignTimeBuild)' != 'true'">
+		<ItemGroup>
+			<JsFiles Include="node_modules/es6-promise/dist/es6-promise.auto.min.js;node_modules/@microsoft/signalr/dist/browser/signalr.min.js;js\$(TargetFramework)\*.js" />
+			<DefFiles Include="js\$(TargetFramework)\*.d.ts" />
+		</ItemGroup>
+		<ItemGroup>
+			<JsFileContents Include="$([System.IO.File]::ReadAllText(%(JsFiles.Identity)))" />
+			<DefFileContents Include="$([System.IO.File]::ReadAllText(%(DefFiles.Identity)))" />
+		</ItemGroup>
+		<WriteLinesToFile File="lib\$(TargetFramework)\drapo.js" Lines="@(JsFileContents)" Overwrite="true" />
+		<WriteLinesToFile File="lib\$(TargetFramework)\drapo.js" Lines="//# sourceMappingURL=drapo.js.map" Overwrite="false" />
+		<WriteLinesToFile File="lib\$(TargetFramework)\drapo.min.js" Lines="@(JsFileContents)" Overwrite="true" />
+		<WriteLinesToFile File="lib\$(TargetFramework)\index.d.ts" Lines="@(DefFileContents)" Overwrite="true" />
+		<ItemGroup>
+			<EmbeddedResource Include="lib\$(TargetFramework)\*.js" WithCulture="false" Type="Non-Resx" />
+		</ItemGroup>
+	</Target>
+
+	<Target Name="CreateDebugLibFiles" AfterTargets="CompileTypeScriptWithTSConfig" Condition="'$(BuildingProject)' == 'true' AND '$(DesignTimeBuild)' != 'true' AND '$(Configuration)' == 'Debug'">
+		<ItemGroup>
+			<LibFiles Include="js\$(TargetFramework)\*.map" />
+		</ItemGroup>
+		<Copy SourceFiles="@(LibFiles)" DestinationFolder="lib\$(TargetFramework)" />
+		<ItemGroup>
+			<EmbeddedResource Include="lib\$(TargetFramework)\*.map" WithCulture="false" Type="Non-Resx" />
+		</ItemGroup>
+	</Target>
+</Project>

--- a/src/Middleware/Drapo/Drapo.csproj
+++ b/src/Middleware/Drapo/Drapo.csproj
@@ -19,29 +19,29 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<Content Include="tsconfig/development/tsconfig.json" Condition="'$(Configuration)' == 'Debug'" />
-		<Content Include="tsconfig/production/tsconfig.json" Condition="'$(Configuration)' == 'Release'" />
+		<Content Include="tsconfig/development/$(TargetFramework)/tsconfig.json" Condition="'$(Configuration)' == 'Debug'" />
+		<Content Include="tsconfig/production/$(TargetFramework)/tsconfig.json" Condition="'$(Configuration)' == 'Release'" />
 	</ItemGroup>
 	<Target Name="FixDeniedAccessOnDelete" BeforeTargets="TypeScriptDeleteOutputFromOtherConfigs" Condition="'$(BuildingProject)' != 'false' AND '$(DesignTimeBuild)' != 'true'">
 		<!-- Messing with the bugged target TypeScriptDeleteOutputFromOtherConfigs from Mricrosoft.TypeScript.targets and make it do nothing: https://github.com/microsoft/TypeScript/issues/50428 -->
 		<ItemGroup>
-			<TSOutputLogsToDelete Include="$(BaseIntermediateOutputPath)\**\Tsc*.out"/>
+			<TSOutputLogsToDelete Include="$(BaseIntermediateOutputPath)\**\Tsc*.out" />
 		</ItemGroup>
 		<Delete Files="@(TSOutputLogsToDelete)" Condition="'@(TSOutputLogsToDelete)' != '' " />
 	</Target>
 	<Target Name="CleanLibFiles" BeforeTargets="Clean" Condition="'$(DesignTimeBuild)' != 'true'">
 		<ItemGroup>
-			<FilesToDelete Include="lib\$(TargetFramework)\**\*;js\*" />
+			<FilesToDelete Include="lib\$(TargetFramework)\**\*;js\$(TargetFramework)\**\*" />
 		</ItemGroup>
 		<Delete Files="@(FilesToDelete)" />
 	</Target>
 	<Target Name="TSLint" BeforeTargets="CompileTypeScriptWithTSConfig" Condition="$(TargetFrameworks.StartsWith($(TargetFramework))) AND '$(BuildingProject)' == 'true' AND '$(DesignTimeBuild)' != 'true'">
-		<Exec Command="npx tslint --project tsconfig/production/" />
+		<Exec Command="npx tslint --project tsconfig/production/tsconfig.base.json" />
 	</Target>
 	<Target Name="CreateLibFiles" AfterTargets="CompileTypeScriptWithTSConfig" Condition="'$(BuildingProject)' == 'true' AND '$(DesignTimeBuild)' != 'true'">
 		<ItemGroup>
-			<JsFiles Include="node_modules/es6-promise/dist/es6-promise.auto.min.js;node_modules/@microsoft/signalr/dist/browser/signalr.min.js;js\*.js" />
-			<DefFiles Include="js\*.d.ts" />
+			<JsFiles Include="node_modules/es6-promise/dist/es6-promise.auto.min.js;node_modules/@microsoft/signalr/dist/browser/signalr.min.js;js\$(TargetFramework)\*.js" />
+			<DefFiles Include="js\$(TargetFramework)\*.d.ts" />
 		</ItemGroup>
 		<ItemGroup>
 			<JsFileContents Include="$([System.IO.File]::ReadAllText(%(JsFiles.Identity)))" />
@@ -57,7 +57,7 @@
 	</Target>
 	<Target Name="CreateDebugLibFiles" AfterTargets="CompileTypeScriptWithTSConfig" Condition="'$(BuildingProject)' == 'true' AND '$(DesignTimeBuild)' != 'true' AND '$(Configuration)' == 'Debug'">
 		<ItemGroup>
-			<LibFiles Include="js\*.map" />
+			<LibFiles Include="js\$(TargetFramework)\*.map" />
 		</ItemGroup>
 		<Copy SourceFiles="@(LibFiles)" DestinationFolder="lib\$(TargetFramework)" />
 		<ItemGroup>

--- a/src/Middleware/Drapo/Drapo.csproj
+++ b/src/Middleware/Drapo/Drapo.csproj
@@ -9,61 +9,6 @@
 		<AssemblyName>Sysphera.Middleware.Drapo</AssemblyName>
 		<RootNamespace>Sysphera.Middleware.Drapo</RootNamespace>
 	</PropertyGroup>
-	<Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.Default.props" Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.Default.props')" />
-	<PropertyGroup>
-		<TypeScriptToolsVersion>Latest</TypeScriptToolsVersion>
-		<TypeScriptCompileBlocked>false</TypeScriptCompileBlocked>
-	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="Microsoft.TypeScript.MSBuild" Version="5.4.5">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<Content Include="tsconfig/development/$(TargetFramework)/tsconfig.json" Condition="'$(Configuration)' == 'Debug'" />
-		<Content Include="tsconfig/production/$(TargetFramework)/tsconfig.json" Condition="'$(Configuration)' == 'Release'" />
-	</ItemGroup>
-	<Target Name="FixDeniedAccessOnDelete" BeforeTargets="TypeScriptDeleteOutputFromOtherConfigs" Condition="'$(BuildingProject)' != 'false' AND '$(DesignTimeBuild)' != 'true'">
-		<!-- Messing with the bugged target TypeScriptDeleteOutputFromOtherConfigs from Mricrosoft.TypeScript.targets and make it do nothing: https://github.com/microsoft/TypeScript/issues/50428 -->
-		<ItemGroup>
-			<TSOutputLogsToDelete Include="$(BaseIntermediateOutputPath)\**\Tsc*.out" />
-		</ItemGroup>
-		<Delete Files="@(TSOutputLogsToDelete)" Condition="'@(TSOutputLogsToDelete)' != '' " />
-	</Target>
-	<Target Name="CleanLibFiles" BeforeTargets="Clean" Condition="'$(DesignTimeBuild)' != 'true'">
-		<ItemGroup>
-			<FilesToDelete Include="lib\$(TargetFramework)\**\*;js\$(TargetFramework)\**\*" />
-		</ItemGroup>
-		<Delete Files="@(FilesToDelete)" />
-	</Target>
-	<Target Name="TSLint" BeforeTargets="CompileTypeScriptWithTSConfig" Condition="$(TargetFrameworks.StartsWith($(TargetFramework))) AND '$(BuildingProject)' == 'true' AND '$(DesignTimeBuild)' != 'true'">
-		<Exec Command="npx tslint --project tsconfig/production/tsconfig.base.json" />
-	</Target>
-	<Target Name="CreateLibFiles" AfterTargets="CompileTypeScriptWithTSConfig" Condition="'$(BuildingProject)' == 'true' AND '$(DesignTimeBuild)' != 'true'">
-		<ItemGroup>
-			<JsFiles Include="node_modules/es6-promise/dist/es6-promise.auto.min.js;node_modules/@microsoft/signalr/dist/browser/signalr.min.js;js\$(TargetFramework)\*.js" />
-			<DefFiles Include="js\$(TargetFramework)\*.d.ts" />
-		</ItemGroup>
-		<ItemGroup>
-			<JsFileContents Include="$([System.IO.File]::ReadAllText(%(JsFiles.Identity)))" />
-			<DefFileContents Include="$([System.IO.File]::ReadAllText(%(DefFiles.Identity)))" />
-		</ItemGroup>
-		<WriteLinesToFile File="lib\$(TargetFramework)\drapo.js" Lines="@(JsFileContents)" Overwrite="true" />
-		<WriteLinesToFile File="lib\$(TargetFramework)\drapo.js" Lines="//# sourceMappingURL=drapo.js.map" Overwrite="false" />
-		<WriteLinesToFile File="lib\$(TargetFramework)\drapo.min.js" Lines="@(JsFileContents)" Overwrite="true" />
-		<WriteLinesToFile File="lib\$(TargetFramework)\index.d.ts" Lines="@(DefFileContents)" Overwrite="true" />
-		<ItemGroup>
-			<EmbeddedResource Include="lib\$(TargetFramework)\*.js" WithCulture="false" Type="Non-Resx" />
-		</ItemGroup>
-	</Target>
-	<Target Name="CreateDebugLibFiles" AfterTargets="CompileTypeScriptWithTSConfig" Condition="'$(BuildingProject)' == 'true' AND '$(DesignTimeBuild)' != 'true' AND '$(Configuration)' == 'Debug'">
-		<ItemGroup>
-			<LibFiles Include="js\$(TargetFramework)\*.map" />
-		</ItemGroup>
-		<Copy SourceFiles="@(LibFiles)" DestinationFolder="lib\$(TargetFramework)" />
-		<ItemGroup>
-			<EmbeddedResource Include="lib\$(TargetFramework)\*.map" WithCulture="false" Type="Non-Resx" />
-		</ItemGroup>
-	</Target>
 	<ItemGroup>
 		<None Remove="components\**\*" />
 	</ItemGroup>
@@ -75,5 +20,5 @@
 		<PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
 		<PackageReference Include="StackExchange.Redis" Version="2.2.50" />
 	</ItemGroup>
-	<Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.targets" Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.targets')" />
+	<Import Project="Drapo.TypeScript.targets" />
 </Project>

--- a/src/Middleware/Drapo/DrapoMiddleware.cs
+++ b/src/Middleware/Drapo/DrapoMiddleware.cs
@@ -272,7 +272,7 @@ namespace Sysphera.Middleware.Drapo
                 string jsOffsetMapContent = null;
                 if (resources.TryGetValue(jsOffset.jsMapFilename, out jsOffsetMapContent))
                 {
-                    jsOffsetMapContent = jsOffsetMapContent.Replace("../ts", $"file:///{localRootPath}/ts");
+                    jsOffsetMapContent = jsOffsetMapContent.Replace("../../ts", $"file:///{localRootPath}/ts");
                     sections.Add($@" {{ ""offset"": {{""line"":{jsOffset.lineOffset}, ""column"":0}}, ""map"": {jsOffsetMapContent} }} ");
                 }
             }

--- a/src/Middleware/Drapo/tsconfig/development/net8.0/tsconfig.json
+++ b/src/Middleware/Drapo/tsconfig/development/net8.0/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../../js/net8.0"
+  }
+}

--- a/src/Middleware/Drapo/tsconfig/development/netcoreapp3.1/tsconfig.json
+++ b/src/Middleware/Drapo/tsconfig/development/netcoreapp3.1/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../../js/netcoreapp3.1"
+  }
+}

--- a/src/Middleware/Drapo/tsconfig/development/netcoreapp6.0/tsconfig.json
+++ b/src/Middleware/Drapo/tsconfig/development/netcoreapp6.0/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../../js/netcoreapp6.0"
+  }
+}

--- a/src/Middleware/Drapo/tsconfig/development/tsconfig.base.json
+++ b/src/Middleware/Drapo/tsconfig/development/tsconfig.base.json
@@ -1,5 +1,5 @@
 {
-  "compileOnSave": true,
+  "compileOnSave": false,
   "compilerOptions": {
     "alwaysStrict": true,
     "noImplicitAny": true,
@@ -10,7 +10,6 @@
     "removeComments": false,
     "sourceMap": true,
     "target": "es2022",
-    "outDir": "../../js/",
     "declaration": true,
     "lib": [
       "dom",

--- a/src/Middleware/Drapo/tsconfig/production/net8.0/tsconfig.json
+++ b/src/Middleware/Drapo/tsconfig/production/net8.0/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../../js/net8.0"
+  }
+}

--- a/src/Middleware/Drapo/tsconfig/production/netcoreapp3.1/tsconfig.json
+++ b/src/Middleware/Drapo/tsconfig/production/netcoreapp3.1/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../../js/netcoreapp3.1"
+  }
+}

--- a/src/Middleware/Drapo/tsconfig/production/netcoreapp6.0/tsconfig.json
+++ b/src/Middleware/Drapo/tsconfig/production/netcoreapp6.0/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../../js/netcoreapp6.0"
+  }
+}

--- a/src/Middleware/Drapo/tsconfig/production/tsconfig.base.json
+++ b/src/Middleware/Drapo/tsconfig/production/tsconfig.base.json
@@ -1,5 +1,5 @@
 {
-  "compileOnSave": true,
+  "compileOnSave": false,
   "compilerOptions": {
     "alwaysStrict": true,
     "noImplicitAny": true,
@@ -10,7 +10,6 @@
     "removeComments": true,
     "sourceMap": false,
     "target": "es5",
-    "outDir": "../../js/",
     "declaration": true,
     "lib": [
       "dom",


### PR DESCRIPTION
- Organization of tsconfig.json files to split JS outputs for each framework, minizing access conflicts
- Organization of TypeScript targets in a separate .targets file