### PR TITLE
Fix on Viewport behavior

### DIFF
--- a/src/Middleware/Drapo/ts/DrapoControlFlow.ts
+++ b/src/Middleware/Drapo/ts/DrapoControlFlow.ts
@@ -294,7 +294,6 @@ class DrapoControlFlow {
             context.Initialize(startViewport - 1);
         const insertedElements = [];
         const elForParentOriginalStyle: string = elAnchor.parentElement.getAttribute("style");
-        elForParent.style.display = 'none';
         for (let j = startViewport; j < endViewport; j++) {
             const data: any = datas[j];
             //Template
@@ -305,6 +304,7 @@ class DrapoControlFlow {
                 this.AddTemplate(context, templateKey, templateData);
             }
             const template: HTMLElement = templateData !== null ? this.Application.Document.Clone(templateData) : this.Application.Document.Clone(forReferenceTemplate);
+            (template as any).isDForSpawn = true;
             const viewportIndexDifference: number = (isViewportActive ? (1 - startViewport) : 0);
             const nodeIndex: number = j - nodesRemovedCount + viewportIndexDifference;
             const oldNode: HTMLElement = ((items !== null) && (nodeIndex < items.length)) ? items[nodeIndex] : null;
@@ -333,11 +333,12 @@ class DrapoControlFlow {
                     lastInserted = template;
                     if (hashValueCurrent !== null)
                         template.setAttribute('d-hash', hashValueCurrent);
-                    if (!this.Application.ViewportHandler.HasHeightChanged(viewport)) {
+                    await this.ResolveControlFlowForIterationRender(sector, context, template, renderContext, true, canResolveComponents);
+                    if (elForParent.style.display != 'none' && !this.Application.ViewportHandler.HasHeightChanged(viewport)) {
                         this.Application.ViewportHandler.UpdateHeightItem(viewport, template);
                         endViewport = this.Application.ViewportHandler.GetViewportControlFlowEnd(viewport, length);
+                        elForParent.style.display = 'none';
                     }
-                    await this.ResolveControlFlowForIterationRender(sector, context, template, renderContext, true, canResolveComponents);
                 }
                 insertedElements.push(lastInserted);
             } else if (type == DrapoStorageLinkType.RenderClass) {
@@ -876,6 +877,7 @@ class DrapoControlFlow {
             const data: any = viewport.Data[i];
             //Template
             const template: HTMLElement = this.Application.Document.Clone(viewport.ElementTemplate);
+            (template as any).isDForSpawn = true;
             const item: DrapoContextItem = context.Create(data, template, template, viewport.DataKey, viewport.Key, viewport.DataKeyIteratorRange, i, null);
             await this.ResolveControlFlowForIterationRender(viewport.Sector, context, template, renderContext, true, true);
             const hashValueCurrent: string = hashTemplate === null ? null : await this.GetElementHashValue(viewport.Sector, context, template, hashTemplate);

--- a/src/Middleware/Drapo/ts/DrapoControlFlow.ts
+++ b/src/Middleware/Drapo/ts/DrapoControlFlow.ts
@@ -17,11 +17,11 @@ class DrapoControlFlow {
         await this.ResolveControlFlowForArray(els);
     }
 
-    public async ResolveControlFlowSector(el: HTMLElement, canResolveComponents: boolean = true): Promise<void> {
+    public async ResolveControlFlowSector(el: HTMLElement): Promise<void> {
         if (el == null)
             return;
         const els: HTMLElement[] = this.Application.Searcher.FindAllByAttributeFromParent('d-for', el);
-        await this.ResolveControlFlowForArray(els, false, true, DrapoStorageLinkType.Render, canResolveComponents);
+        await this.ResolveControlFlowForArray(els, false, true, DrapoStorageLinkType.Render);
     }
 
     private ResolveControlFlowForParent(forElement: HTMLElement): HTMLElement {
@@ -42,13 +42,13 @@ class DrapoControlFlow {
         return (forElement);
     }
 
-    public async ResolveControlFlowForElement(forElement: HTMLElement, isIncremental: boolean = false, canUseDifference: boolean = true, type: DrapoStorageLinkType = DrapoStorageLinkType.Render, canResolveComponents: boolean = true): Promise<void> {
+    public async ResolveControlFlowForElement(forElement: HTMLElement, isIncremental: boolean = false, canUseDifference: boolean = true, type: DrapoStorageLinkType = DrapoStorageLinkType.Render): Promise<void> {
         const forElements: HTMLElement[] = [];
         forElements.push(forElement);
-        return (await this.ResolveControlFlowForArray(forElements, isIncremental, canUseDifference, type, canResolveComponents));
+        return (await this.ResolveControlFlowForArray(forElements, isIncremental, canUseDifference, type));
     }
 
-    public async ResolveControlFlowForArray(forElements: HTMLElement[], isIncremental: boolean = false, canUseDifference: boolean = true, type: DrapoStorageLinkType = DrapoStorageLinkType.Render, canResolveComponents: boolean = true): Promise<void> {
+    public async ResolveControlFlowForArray(forElements: HTMLElement[], isIncremental: boolean = false, canUseDifference: boolean = true, type: DrapoStorageLinkType = DrapoStorageLinkType.Render): Promise<void> {
         const forElementsInserted: HTMLElement[] = [];
         for (let i = 0; i < forElements.length; i++) {
             const forElement: HTMLElement = forElements[i];
@@ -65,7 +65,7 @@ class DrapoControlFlow {
             if (!this.Application.Document.IsSectorReady(sector))
                 continue;
             const renderContext: DrapoRenderContext = new DrapoRenderContext();
-            await this.ResolveControlFlowForInternal(sector, context, renderContext, forElementRoot, isIncremental, canUseDifference, type, canResolveComponents);
+            await this.ResolveControlFlowForInternal(sector, context, renderContext, forElementRoot, isIncremental, canUseDifference, type);
         }
     }
 
@@ -111,7 +111,7 @@ class DrapoControlFlow {
         return (el.style.display === 'none');
     }
 
-    private async ResolveControlFlowForInternal(sector: string, context: DrapoContext, renderContext: DrapoRenderContext, elFor: HTMLElement, isIncremental: boolean, canUseDifference: boolean = true, type: DrapoStorageLinkType = DrapoStorageLinkType.Render, canResolveComponents: boolean = true): Promise<boolean> {
+    private async ResolveControlFlowForInternal(sector: string, context: DrapoContext, renderContext: DrapoRenderContext, elFor: HTMLElement, isIncremental: boolean, canUseDifference: boolean = true, type: DrapoStorageLinkType = DrapoStorageLinkType.Render): Promise<boolean> {
         let forText: string = elFor.getAttribute('d-for');
         let ifText: string = null;
         let forIfText: string = null;
@@ -322,7 +322,7 @@ class DrapoControlFlow {
                 const applyHash: boolean = ((!useHash) || (hashValueCurrent !== hashValueBefore));
                 if (((isDifference) || (isViewportActive)) && (oldNode != null)) {
                     if (applyHash)
-                        await this.ResolveControlFlowForIterationRender(sector, context, template, renderContext, true, canResolveComponents);
+                        await this.ResolveControlFlowForIterationRender(sector, context, template, renderContext, true, true);
                     if (applyHash)
                         this.Application.Document.ApplyNodeDifferences(oldNode.parentElement, oldNode, template, isHTML);
                     if (hashValueCurrent !== null)
@@ -333,7 +333,7 @@ class DrapoControlFlow {
                     lastInserted = template;
                     if (hashValueCurrent !== null)
                         template.setAttribute('d-hash', hashValueCurrent);
-                    await this.ResolveControlFlowForIterationRender(sector, context, template, renderContext, true, canResolveComponents);
+                    await this.ResolveControlFlowForIterationRender(sector, context, template, renderContext, true, true);
                     if (elForParent.style.display != 'none' && !this.Application.ViewportHandler.HasHeightChanged(viewport)) {
                         this.Application.ViewportHandler.UpdateHeightItem(viewport, template);
                         endViewport = this.Application.ViewportHandler.GetViewportControlFlowEnd(viewport, length);

--- a/src/Middleware/Drapo/ts/DrapoDocument.ts
+++ b/src/Middleware/Drapo/ts/DrapoDocument.ts
@@ -611,6 +611,8 @@ class DrapoDocument {
         const dfor: string = el.getAttribute('d-for');
         if (dfor != null)
             return (true);
+        if ((el as any).isDForSpawn === true)
+            return (true);
         const elParent: HTMLElement = el.parentElement;
         if (elParent == null)
             return (true);

--- a/src/Middleware/Drapo/ts/DrapoDocument.ts
+++ b/src/Middleware/Drapo/ts/DrapoDocument.ts
@@ -306,7 +306,7 @@ class DrapoDocument {
         //Storage Before
         await this.Application.Storage.ResolveData(false, elWindow);
         //Control Flow
-        await this.Application.ControlFlow.ResolveControlFlowSector(elWindow, false);
+        await this.Application.ControlFlow.ResolveControlFlowSector(elWindow);
         //Components
         await this.Application.ComponentHandler.ResolveComponents(elWindow);
         //Storage After

--- a/src/Web/WebDrapo/wwwroot/DrapoPages/Bug_DClassBeforeDFor.html
+++ b/src/Web/WebDrapo/wwwroot/DrapoPages/Bug_DClassBeforeDFor.html
@@ -1,0 +1,46 @@
+﻿<!DOCTYPE html>
+<html>
+<head>
+    <script src="/drapo.js"></script>
+    <title>Control Flow - For - Viewport - Flex - Parent</title>
+    <style>
+        .flexContainer {
+            display: flex;
+            flex-direction: column;
+            gap: 1px;
+            align-items: stretch;
+            height: 170px;
+            width: 100%;
+            border: solid red 1px;
+            padding: 1px;
+        }
+        .displayNone {
+            display: none;
+        }
+        .flexMainItem {
+            flex-grow: 1;
+        }
+    </style>
+</head>
+<body>
+    <span>Control Flow - For - Viewport - Flex - Parent</span>
+    <p>
+        All d-fors are processed before existing d-classes.
+        Then the box with {displayNone} will fill all the height of its parent, leaving no room for the next d-for with a viewport.
+        This leads to missbehaviour in the viewport, where it won't paginate its items and show all of them.
+    </p>
+    <div d-dataKey="items" d-dataUrlGet="/Data/GetLevels?Levels=0&Children=300"></div>
+    <div class="flexContainer">
+        <div d-class="{displayNone}" style="border: solid blue 1px">
+            <div d-for="item in items[0..10]">
+                <span>[x]</span>
+            </div>
+        </div>
+        <div class="flexMainItem" style="overflow-y: scroll; border: solid green 1px">
+            <div d-for="item in items" d-for-render="viewport">
+                <d-checkbox dc-value="{{item.Visible}}" dc-label="{{item.Key}}"></d-checkbox>
+            </div>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION

This pull request refactors the control flow logic in the Drapo framework to simplify method signatures and improve handling of dynamically spawned elements. It also adds a new test page to demonstrate and debug a specific issue related to control flow and CSS class application order. The most important changes are grouped below:

### Control Flow Refactoring

* Removed the `canResolveComponents` parameter from several methods in `DrapoControlFlow` (`ResolveControlFlowSector`, `ResolveControlFlowForElement`, `ResolveControlFlowForArray`, and `ResolveControlFlowForInternal`) to streamline method signatures and internal logic. [[1]](diffhunk://#diff-94216f8978edcb75142aaf1b356ccdb3461df1cea2d662f03d9d661a2f438357L20-R24) [[2]](diffhunk://#diff-94216f8978edcb75142aaf1b356ccdb3461df1cea2d662f03d9d661a2f438357L45-R51) [[3]](diffhunk://#diff-94216f8978edcb75142aaf1b356ccdb3461df1cea2d662f03d9d661a2f438357L68-R68) [[4]](diffhunk://#diff-94216f8978edcb75142aaf1b356ccdb3461df1cea2d662f03d9d661a2f438357L114-R114)
* Updated related method calls in `DrapoDocument` to match the new method signatures, ensuring compatibility across the codebase.

### Dynamic Element Handling

* Introduced the `isDForSpawn` property on dynamically created elements during control flow iteration, allowing the framework to distinguish spawned elements and handle them appropriately. [[1]](diffhunk://#diff-94216f8978edcb75142aaf1b356ccdb3461df1cea2d662f03d9d661a2f438357R307) [[2]](diffhunk://#diff-94216f8978edcb75142aaf1b356ccdb3461df1cea2d662f03d9d661a2f438357R880)
* Enhanced the logic in `DrapoDocument` to recognize elements with the `isDForSpawn` property as control flow elements, improving rendering accuracy and consistency.

### Viewport and Display Logic

* Adjusted the control flow rendering logic to better manage parent element display states when updating viewports, preventing layout issues caused by CSS class application order and ensuring correct pagination and visibility. [[1]](diffhunk://#diff-94216f8978edcb75142aaf1b356ccdb3461df1cea2d662f03d9d661a2f438357L297) [[2]](diffhunk://#diff-94216f8978edcb75142aaf1b356ccdb3461df1cea2d662f03d9d661a2f438357L325-R325) [[3]](diffhunk://#diff-94216f8978edcb75142aaf1b356ccdb3461df1cea2d662f03d9d661a2f438357L336-L340)

### Testing and Debugging

* Added a new HTML test page (`Bug_DClassBeforeDFor.html`) to reproduce and analyze the bug where d-for elements are processed before d-class, leading to incorrect viewport behavior and display issues.