### PR TITLE
New functions to add/remove css classes from HTML elements

### DIFF
--- a/src/Middleware/Drapo/ts/DrapoFunctionHandler.ts
+++ b/src/Middleware/Drapo/ts/DrapoFunctionHandler.ts
@@ -409,6 +409,10 @@ class DrapoFunctionHandler {
             return (await this.ExecuteFunctionDebugger(sector, contextItem, element, event, functionParsed, executionContext));
         if (functionParsed.Name === 'break')
             return (await this.ExecuteFunctionBreak(sector, contextItem, element, event, functionParsed, executionContext));
+        if (functionParsed.Name === 'addclass')
+            return (await this.ExecuteFunctionAddClass(sector, contextItem, element, event, functionParsed, executionContext));
+        if (functionParsed.Name === 'removeclass')
+            return (await this.ExecuteFunctionRemoveClass(sector, contextItem, element, event, functionParsed, executionContext));
         if (!checkInvalidFunction)
             return (null);
         await this.Application.ExceptionHandler.HandleError('DrapoFunctionHandler - ExecuteFunction - Invalid Function - {0}', functionParsed.Name);
@@ -1711,5 +1715,25 @@ class DrapoFunctionHandler {
         if (this.Application.Solver.Contains(functions, functionParsed.Name))
             return (true);
         return (false);
+    }
+
+    private async ExecuteFunctionAddClass(sector: string, contextItem: DrapoContextItem, element: HTMLElement, event: Event, functionParsed: DrapoFunction, executionContext: DrapoExecutionContext<any>): Promise<boolean> {
+        const className: string = (await this.ResolveFunctionParameter(sector, contextItem, element, executionContext, functionParsed.Parameters[0]))?.trim() ?? '';
+        if (functionParsed.Parameters.length > 1) {
+            const elementId: string = (await this.ResolveFunctionParameter(sector, contextItem, element, executionContext, functionParsed.Parameters[1]))?.trim() ?? '';
+            element = document.getElementById(elementId);
+        }
+        element?.classList.add(className);
+        return true;
+    }
+
+    private async ExecuteFunctionRemoveClass(sector: string, contextItem: DrapoContextItem, element: HTMLElement, event: Event, functionParsed: DrapoFunction, executionContext: DrapoExecutionContext<any>): Promise<boolean> {
+        const className: string = (await this.ResolveFunctionParameter(sector, contextItem, element, executionContext, functionParsed.Parameters[0]))?.trim() ?? '';
+        if (functionParsed.Parameters.length > 1) {
+            const elementId: string = (await this.ResolveFunctionParameter(sector, contextItem, element, executionContext, functionParsed.Parameters[1]))?.trim() ?? '';
+            element = document.getElementById(elementId);
+        }
+        element?.classList.remove(className);
+        return true;
     }
 }

--- a/src/Web/WebDrapo/wwwroot/DrapoPages/FunctionAddClass.html
+++ b/src/Web/WebDrapo/wwwroot/DrapoPages/FunctionAddClass.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="/drapo.js"></script>
+    <title>Function - AddClass and RemoveClass</title>
+    <style>
+        .bold {
+            font-weight: bold;
+        }
+    </style>
+</head>
+<body>
+    <br>
+    <span id="sentence" d-on-click="AddClass(bold)">Click here to make this sentence bold.</span>
+    <br><br>
+    <input type="button" value="Revert to normal" d-on-click="RemoveClass(bold,sentence)">
+</body>
+</html>


### PR DESCRIPTION
This pull request introduces two new utility functions to the Drapo framework for manipulating CSS classes directly from Drapo function calls. It also adds a sample HTML page demonstrating their usage. The main changes are grouped below:

### New Functionality in DrapoFunctionHandler

* Added support for the `addclass` and `removeclass` function names in `DrapoFunctionHandler`, enabling direct manipulation of element classes from Drapo function calls.
* Implemented the private methods `ExecuteFunctionAddClass` and `ExecuteFunctionRemoveClass` to handle adding and removing CSS classes, respectively. These methods support targeting elements by ID and ensure parameters are properly resolved and trimmed.

### Documentation & Example

* Added a new HTML page `FunctionAddClass.html` demonstrating how to use the new `AddClass` and `RemoveClass` functions to toggle a `bold` class on a sentence element.