### PR TITLE
Component constructors being called multiple times

### DIFF
--- a/src/Web/WebDrapo/Properties/launchSettings.json
+++ b/src/Web/WebDrapo/Properties/launchSettings.json
@@ -15,7 +15,7 @@
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
-      "launchUrl": "DrapoPages/ValidationEventConditionalBlocks.html",
+      "launchUrl": "DrapoPages/NestedComponentsAndDfor1.html",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
@@ -24,7 +24,7 @@
     "IIS Express Prod": {
       "commandName": "IISExpress",
       "launchBrowser": true,
-      "launchUrl": "DrapoPages/ValidationEventConditionalBlocks.html",
+      "launchUrl": "DrapoPages/NestedComponentsAndDfor1.html",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Production"
       },

--- a/src/Web/WebDrapo/wwwroot/DrapoPages/NestedComponentsAndDfor1.html
+++ b/src/Web/WebDrapo/wwwroot/DrapoPages/NestedComponentsAndDfor1.html
@@ -1,0 +1,11 @@
+﻿<!DOCTYPE html>
+<html>
+<head>
+    <script src="/drapo.js"></script>
+    <title>Nested Component</title>
+</head>
+<body>
+    <div d-dataKey="LoadContent" d-dataType="function" d-dataLoadType="startup" d-dataValue="Async(UpdateSector(dynamicContent,~/DrapoPages/NestedComponentsAndDfor2.html,,false))"></div>
+    <div d-sector="dynamicContent"></div>
+</body>
+</html>

--- a/src/Web/WebDrapo/wwwroot/DrapoPages/NestedComponentsAndDfor2.html
+++ b/src/Web/WebDrapo/wwwroot/DrapoPages/NestedComponentsAndDfor2.html
@@ -1,0 +1,11 @@
+﻿<!DOCTYPE html>
+<script src="/drapo.js"></script>
+
+<div class="content">
+    <div d-dataKey="data" d-dataType="object" d-dataUrlGet="/Data/GetLevels?levels=0&children=1"></div>
+    <d-importedtags>
+        <div d-for="datum in data">
+            <d-datavalue d-dataValue="{{datum.Value}}"></d-datavalue>
+        </div>
+    </d-importedtags>
+</div>

--- a/src/Web/WebDrapo/wwwroot/components/importedtags/importedtags.html
+++ b/src/Web/WebDrapo/wwwroot/components/importedtags/importedtags.html
@@ -1,0 +1,5 @@
+<div d-sector="@" dc-model="">
+    <div d-dataKey="internal" d-dataType="parent" d-dataValue="dc-" d-dataloadtype="reference"></div>
+    Imported content:
+    <div d-content="internal"></div>
+</div>

--- a/src/Web/WebDrapo/wwwroot/components/importedtags/importedtags.ts
+++ b/src/Web/WebDrapo/wwwroot/components/importedtags/importedtags.ts
@@ -1,0 +1,15 @@
+﻿async function importedtagsConstructor(el: HTMLElement, app: DrapoApplication): Promise<any> {
+    //Initialize
+    const instance: ImportedTags = new ImportedTags(el, app);
+    await instance.Initalize();
+    return instance;
+}
+
+class ImportedTags {
+    constructor(el: HTMLElement, app: any) {
+    }
+
+    public async Initalize(): Promise<void> {
+    }
+
+}


### PR DESCRIPTION
In this example setup, the constructor of the component "d-datavalue" is called 3 times for each component instantiated by the d-for.

A possible point of problem is the recursion on DrapoDocument.LoadChildSectorInternal() > DrapoDocument.ResolveChildren() > DrapoDocument.LoadChildSectorInternal(), where the d-for will be activated multiple times.