### PR TITLE
Fix duplicate index.d.ts destination in Package.nuspec

### DIFF
--- a/Package.nuspec
+++ b/Package.nuspec
@@ -18,7 +18,6 @@
     <file src="src\Middleware\Drapo\bin\Release\net8.0\Sysphera.Middleware.Drapo.dll" target="lib\net8.0\" />
     <file src="src\Middleware\Drapo\bin\Release\net10.0\Sysphera.Middleware.Drapo.dll" target="lib\net10.0\" />
     <file src="src\**\*.*" exclude="src\**\*.*" />
-    <file src="src\Middleware\Drapo\lib\net8.0\*.d.ts" target="contentFiles\any\any\node_modules\@types\drapo" />
     <file src="src\Middleware\Drapo\lib\net10.0\*.d.ts" target="contentFiles\any\any\node_modules\@types\drapo" />
 	<file src="src\Middleware\Drapo\build\**" target="build" />
   </files>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "10.0.100",
-    "rollForward": "latestFeature"
+    "rollForward": "latestMajor"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "10.0.100",
-    "rollForward": "latestMajor"
+    "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
## Problem\nThe .NET 10 support branch added a second \index.d.ts\ entry in \Package.nuspec\ targeting the same NuGet destination as the existing \
et8.0\ entry:\n\n\\\\ncontentFiles\\any\\any\\node_modules\\@types\\drapo\\index.d.ts\n\\\\n\nThis caused NuGet error **NU5050** during \
uget pack\ in the CI pipeline.\n\n## Fix\nRemoved the duplicate \
et8.0\ entry, keeping only \
et10.0\ as the single source for the TypeScript definitions — the latest framework target in the package.