### PR TITLE
Fix GetSectorImage: inline images and strip invalid XML attribute names

### DIFF
--- a/src/Middleware/Drapo/ts/DrapoDiagnostics.ts
+++ b/src/Middleware/Drapo/ts/DrapoDiagnostics.ts
@@ -73,6 +73,9 @@ class DrapoDiagnostics {
         const width: number = Math.round(rect.width);
         if ((width <= 0) || (height <= 0))
             return (null);
+        const clone: HTMLElement = element.cloneNode(true) as HTMLElement;
+        await this.InlineAbsoluteImages(clone);
+        this.StripInvalidXmlAttributes(clone);
         const svgNS: string = 'http://www.w3.org/2000/svg';
         const svgElement: SVGSVGElement = document.createElementNS(svgNS, 'svg') as SVGSVGElement;
         svgElement.setAttribute('height', String(height));
@@ -81,7 +84,7 @@ class DrapoDiagnostics {
         const foreignObject: SVGForeignObjectElement = document.createElementNS(svgNS, 'foreignObject') as SVGForeignObjectElement;
         foreignObject.setAttribute('height', '100%');
         foreignObject.setAttribute('width', '100%');
-        foreignObject.appendChild(element.cloneNode(true));
+        foreignObject.appendChild(clone);
         svgElement.appendChild(foreignObject);
         const svgDataUrl: string = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(new XMLSerializer().serializeToString(svgElement));
         const img: HTMLImageElement = await this.LoadImage(svgDataUrl);
@@ -108,6 +111,50 @@ class DrapoDiagnostics {
             img.onload = () => { window.clearTimeout(timeoutHandle); resolve(img); };
             img.onerror = () => { window.clearTimeout(timeoutHandle); resolve(null); };
             img.src = src;
+        }));
+    }
+
+    // Removes attributes whose names are invalid in XML from the entire element subtree.
+    // HTML allows attribute names like ")" or "!" that would break XML/SVG parsing.
+    private StripInvalidXmlAttributes(element: HTMLElement): void {
+        const xmlNameRegex: RegExp = /^[a-zA-Z_][a-zA-Z0-9\-_\.:]*$/;
+        const allElements: Element[] = Array.from(element.querySelectorAll('*'));
+        allElements.push(element);
+        for (const el of allElements) {
+            const toRemove: string[] = [];
+            for (let i: number = 0; i < el.attributes.length; i++) {
+                const attrName: string = el.attributes[i].name;
+                if (!xmlNameRegex.test(attrName))
+                    toRemove.push(attrName);
+            }
+            for (const name of toRemove)
+                el.removeAttribute(name);
+        }
+    }
+
+    // Replaces absolute HTTP/HTTPS src attributes in a cloned element tree with
+    // inline base64 data URLs so SVG foreignObject serialization can render them.
+    // Cross-origin images that fail the fetch are silently left unchanged.
+    private async InlineAbsoluteImages(element: HTMLElement): Promise<void> {
+        const imgs: Element[] = Array.from(element.querySelectorAll('[src^="http://"], [src^="https://"]'));
+        await Promise.all(imgs.map(async (img: Element) => {
+            const src: string = img.getAttribute('src');
+            try {
+                const response: Response = await fetch(src, { credentials: 'include' });
+                if (!response.ok)
+                    return;
+                const blob: Blob = await response.blob();
+                const dataUrl: string = await new Promise<string>((resolve) => {
+                    const reader: FileReader = new FileReader();
+                    reader.onload = () => resolve(reader.result as string);
+                    reader.onerror = () => resolve(null);
+                    reader.readAsDataURL(blob);
+                });
+                if (dataUrl != null)
+                    img.setAttribute('src', dataUrl);
+            } catch {
+                // Leave as-is if fetch fails (cross-origin or network error)
+            }
         }));
     }
 

--- a/src/Middleware/Drapo/ts/DrapoDiagnostics.ts
+++ b/src/Middleware/Drapo/ts/DrapoDiagnostics.ts
@@ -75,6 +75,7 @@ class DrapoDiagnostics {
             return (null);
         const clone: HTMLElement = element.cloneNode(true) as HTMLElement;
         await this.InlineAbsoluteImages(clone);
+        await this.InlineStylesheets(clone);
         this.StripInvalidXmlAttributes(clone);
         const svgNS: string = 'http://www.w3.org/2000/svg';
         const svgElement: SVGSVGElement = document.createElementNS(svgNS, 'svg') as SVGSVGElement;
@@ -112,6 +113,35 @@ class DrapoDiagnostics {
             img.onerror = () => { window.clearTimeout(timeoutHandle); resolve(null); };
             img.src = src;
         }));
+    }
+
+    // Fetches all external stylesheets and inline <style> blocks from the document
+    // and injects them as a single <style> element into the clone so that
+    // SVG foreignObject rendering (which cannot load external CSS) shows correct styles.
+    private async InlineStylesheets(element: HTMLElement): Promise<void> {
+        const cssTexts: string[] = [];
+        const linkElements: NodeListOf<HTMLLinkElement> = document.querySelectorAll('link[rel="stylesheet"]');
+        await Promise.all(Array.from(linkElements).map(async (link: HTMLLinkElement) => {
+            const href: string = link.href;
+            if (!href)
+                return;
+            try {
+                const response: Response = await fetch(href, { credentials: 'include' });
+                if (!response.ok)
+                    return;
+                cssTexts.push(await response.text());
+            } catch {
+                // Skip stylesheets that fail to load
+            }
+        }));
+        const inlineStyles: NodeListOf<HTMLStyleElement> = document.querySelectorAll('style');
+        for (const style of Array.from(inlineStyles))
+            cssTexts.push(style.textContent || '');
+        if (cssTexts.length === 0)
+            return;
+        const styleElement: HTMLStyleElement = document.createElement('style');
+        styleElement.textContent = cssTexts.join('\n');
+        element.insertBefore(styleElement, element.firstChild);
     }
 
     // Removes attributes whose names are invalid in XML from the entire element subtree.

--- a/src/Middleware/Drapo/ts/DrapoDiagnostics.ts
+++ b/src/Middleware/Drapo/ts/DrapoDiagnostics.ts
@@ -115,9 +115,10 @@ class DrapoDiagnostics {
         }));
     }
 
-    // Fetches all external stylesheets and inline <style> blocks from the document
-    // and injects them as a single <style> element into the clone so that
-    // SVG foreignObject rendering (which cannot load external CSS) shows correct styles.
+    // Fetches all external stylesheets and inline <style> blocks from the document,
+    // inlines all url() references (fonts, images) as base64 data URLs, and injects
+    // everything as a single <style> element into the clone so that SVG foreignObject
+    // rendering (which cannot load external resources) shows correct styles and fonts.
     private async InlineStylesheets(element: HTMLElement): Promise<void> {
         const cssTexts: string[] = [];
         const linkElements: NodeListOf<HTMLLinkElement> = document.querySelectorAll('link[rel="stylesheet"]');
@@ -129,7 +130,8 @@ class DrapoDiagnostics {
                 const response: Response = await fetch(href, { credentials: 'include' });
                 if (!response.ok)
                     return;
-                cssTexts.push(await response.text());
+                const cssText: string = await response.text();
+                cssTexts.push(await this.InlineCssUrls(cssText, href));
             } catch {
                 // Skip stylesheets that fail to load
             }
@@ -142,6 +144,45 @@ class DrapoDiagnostics {
         const styleElement: HTMLStyleElement = document.createElement('style');
         styleElement.textContent = cssTexts.join('\n');
         element.insertBefore(styleElement, element.firstChild);
+    }
+
+    // Resolves all url(...) references in a CSS string relative to baseUrl,
+    // fetches them and replaces with inline base64 data URLs.
+    private async InlineCssUrls(cssText: string, baseUrl: string): Promise<string> {
+        const urlRegex: RegExp = /url\(\s*['"]?([^'")\s]+)['"]?\s*\)/g;
+        const matches: Array<{ raw: string; resolved: string }> = [];
+        let m: RegExpExecArray;
+        while ((m = urlRegex.exec(cssText)) !== null) {
+            const raw: string = m[1];
+            if (raw.startsWith('data:'))
+                continue;
+            matches.push({ raw, resolved: new URL(raw, baseUrl).href });
+        }
+        const cache: Map<string, string> = new Map();
+        await Promise.all(matches.map(async ({ resolved }) => {
+            if (cache.has(resolved))
+                return;
+            try {
+                const response: Response = await fetch(resolved, { credentials: 'include' });
+                if (!response.ok) { cache.set(resolved, null); return; }
+                const blob: Blob = await response.blob();
+                const dataUrl: string = await new Promise<string>((resolve) => {
+                    const reader: FileReader = new FileReader();
+                    reader.onload = () => resolve(reader.result as string);
+                    reader.onerror = () => resolve(null);
+                    reader.readAsDataURL(blob);
+                });
+                cache.set(resolved, dataUrl);
+            } catch {
+                cache.set(resolved, null);
+            }
+        }));
+        return cssText.replace(/url\(\s*['"]?([^'")\s]+)['"]?\s*\)/g, (_match: string, raw: string) => {
+            if (raw.startsWith('data:'))
+                return _match;
+            const dataUrl: string = cache.get(new URL(raw, baseUrl).href);
+            return dataUrl ? `url("${dataUrl}")` : _match;
+        });
     }
 
     // Removes attributes whose names are invalid in XML from the entire element subtree.


### PR DESCRIPTION
## Problem
GetSectorImage was returning null in PowerPlanning due to two issues:

1. Absolute HTTP/HTTPS image URLs fail inside SVG foreignObject data: URLs
2. Invalid XML attribute names (e.g. ')' from HTML typo) break the XML parser

## Solution
- InlineAbsoluteImages: fetches absolute-URL images and replaces with base64 data: URLs
- StripInvalidXmlAttributes: removes attributes with names invalid in XML

## Result
GetSectorImage(null) now successfully captures a PNG of the full page.
