### PR TITLE
Fix GetSectorImage clipping: use scrollWidth/scrollHeight for full content capture

### DIFF
--- a/src/Middleware/Drapo/ts/DrapoDiagnostics.ts
+++ b/src/Middleware/Drapo/ts/DrapoDiagnostics.ts
@@ -69,8 +69,8 @@ class DrapoDiagnostics {
 
     private async RenderElementToBase64(element: HTMLElement): Promise<string> {
         const rect: ClientRect = element.getBoundingClientRect();
-        const height: number = Math.round(rect.height);
-        const width: number = Math.round(rect.width);
+        const width: number = element.scrollWidth > 0 ? element.scrollWidth : Math.round(rect.width);
+        const height: number = element.scrollHeight > 0 ? element.scrollHeight : Math.round(rect.height);
         if ((width <= 0) || (height <= 0))
             return (null);
         const clone: HTMLElement = element.cloneNode(true) as HTMLElement;


### PR DESCRIPTION
Fixes #644

## Problem
`GetSectorImage` sized the SVG/canvas using `getBoundingClientRect().width/height`, which only reflects the **visible viewport** area. Sectors with overflow (horizontal/vertical scroll) had their content clipped in the screenshot.

## Fix
Use `element.scrollWidth` / `element.scrollHeight` to size the canvas, with `getBoundingClientRect` as fallback when they are zero.

\\\	ypescript
// Before
const height = Math.round(rect.height);
const width  = Math.round(rect.width);

// After
const width  = element.scrollWidth  > 0 ? element.scrollWidth  : Math.round(rect.width);
const height = element.scrollHeight > 0 ? element.scrollHeight : Math.round(rect.height);
\\\

## Testing
Verified in PowerPlanning E2E: capturing the `content` sector now includes all scrollable content without clipping.