### PR TITLE
Fix pack file load order: sort files alphabetically in ResolvePackFiles

### DIFF
--- a/src/Middleware/Drapo/DrapoMiddleware.cs
+++ b/src/Middleware/Drapo/DrapoMiddleware.cs
@@ -577,6 +577,8 @@ namespace Sysphera.Middleware.Drapo
                     return !pack.ExcludePaths.Any(exclude => this.MatchesPattern(relativePath, exclude));
                 }).ToList();
             }
+            // Sort alphabetically to ensure consistent script load order on all file systems
+            allFiles.Sort(StringComparer.OrdinalIgnoreCase);
             return allFiles.ToArray();
         }
 


### PR DESCRIPTION
## Problem

ResolvePackFiles uses Directory.GetFiles() which on Linux returns files in inode/creation order (not alphabetical). This caused scripts to be injected in the wrong order — e.g. \WorkflowProcessVO.js\ (extends \WorkflowProcessItemCollectionVO\) was injected before \WorkflowProcessItem.js\ (which defines \WorkflowProcessItemCollectionVO\), resulting in:

\\\
ReferenceError: WorkflowProcessItemCollectionVO is not defined
\\\

## Fix

Add \llFiles.Sort(StringComparer.OrdinalIgnoreCase)\ before returning from \ResolvePackFiles\, guaranteeing consistent alphabetical ordering on all file systems (Linux ext4, Windows NTFS, etc).