### PR TITLE
i651: Add runtime snapshot (DrapoIntrospection.GetSnapshot) for tooling/LLM agents

### DIFF
--- a/src/Middleware/Drapo/ts/DrapoIntrospection.ts
+++ b/src/Middleware/Drapo/ts/DrapoIntrospection.ts
@@ -45,6 +45,21 @@ class DrapoIntrospection {
         });
     }
 
+    // One-call snapshot of the running application for external tooling (LLM/agent drivers,
+    // test harnesses): runtime state + sectors + data keys by sector + recent diagnostics.
+    public GetSnapshot(diagnosticsCount: number = null, diagnosticsLevelFilter: string | string[] = null): DrapoRuntimeSnapshot {
+        const sectors: string[] = this.GetSectors();
+        const dataKeysBySector: { [sector: string]: string[] } = {};
+        for (let i: number = 0; i < sectors.length; i++)
+            dataKeysBySector[sectors[i]] = this.GetDataKeys(sectors[i]);
+        return ({
+            dataKeysBySector,
+            diagnostics: this.Application.Diagnostics.GetErrorBuffer(diagnosticsCount, diagnosticsLevelFilter),
+            sectors,
+            state: this.GetRuntimeState()
+        });
+    }
+
     private GetBrowserState(): { width: number; height: number } {
         const documentElement: HTMLElement = this._window.document.documentElement;
         const body: HTMLElement = this._window.document.body;

--- a/src/Middleware/Drapo/ts/DrapoRuntimeSnapshot.ts
+++ b/src/Middleware/Drapo/ts/DrapoRuntimeSnapshot.ts
@@ -1,0 +1,6 @@
+interface DrapoRuntimeSnapshot {
+    state: DrapoRuntimeState;
+    sectors: string[];
+    dataKeysBySector: { [sector: string]: string[] };
+    diagnostics: DrapoDiagnosticEntry[];
+}


### PR DESCRIPTION
## What

Adds `DrapoIntrospection.GetSnapshot()` — a one-call snapshot of the running app for external tooling (Playwright/Selenium drivers, LLM agents, the debugger), via the stable global `window.drapo.Introspection.GetSnapshot()`:

```
{ state, sectors, dataKeysBySector, diagnostics }
```

Closes #651. **Code-only** — the API documentation lives in the docs repo so it surfaces through the MCP: spadrapo/docs#348.

## Design
- Lives on **`DrapoIntrospection`** next to its building blocks (`GetSectors`, `GetDataKeys`, `GetRuntimeState`), which it calls directly via `this.*`; only the diagnostics slice comes from `Application.Diagnostics`.
- The `DrapoRuntimeSnapshot` interface is in **its own file** (`DrapoRuntimeSnapshot.ts`).
- **Additive only** — `DrapoDiagnostics` is untouched (identical to master); the debugger and other consumers are unaffected.
- `window.drapo` is string-keyed and member names survive the production minifier, so the accessor is minification-safe.

## Files (2, +21)
- `ts/DrapoIntrospection.ts` — `GetSnapshot`
- `ts/DrapoRuntimeSnapshot.ts` — the snapshot interface (new file)

## Verification
- `tsc -p tsconfig/production --noEmit` → 0 errors; `tslint` → clean.
- Built WebDrapo; full Selenium suite **343/343**; **Playwright E2E 6/6** against the live app — `Introspection.GetSnapshot` present, `Diagnostics.GetSnapshot` undefined, snapshot returns real data (`dataKeysBySector: {"1":["value","values"],...}`, `state.isLoaded === true`), pages render error-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)