### PR TITLE
Fix DrapoValidator crash on bare 'd' attributes (e.g. SVG <path d="...">)

### DIFF
--- a/src/Middleware/Drapo/ts/DrapoValidator.ts
+++ b/src/Middleware/Drapo/ts/DrapoValidator.ts
@@ -260,7 +260,7 @@ class DrapoValidator {
 
     private ExtractValidationProperty(property: string): string {
         const parse: string[] = this.Application.Parser.ParseProperty(property);
-        if (parse[0] != 'd')
+        if (parse[0] != 'd' || parse.length < 2) // bare 'd' (e.g. SVG <path d="...">) is not a validation
             return (null);
         if (parse[1].toLowerCase() != 'validation')
             return (null);

--- a/src/Test/WebDrapo.Test/Pages/ValidationSvgPath.Test.html
+++ b/src/Test/WebDrapo.Test/Pages/ValidationSvgPath.Test.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml"><head>
+    <script src="/drapo.js"></script>
+    <link href="../css/validation.css" rel="stylesheet" />
+    <title>Validation Svg Path</title>
+</head>
+<body>
+    <div d-id="Windows" d-sector="@" d-on-body-keyup-escape="CloseWindow()"></div>
+    <br />
+    <span>Validation Svg Path</span>
+    <div class="" d-cloak="cloak">
+        <div>
+            <!--Data-->
+            <div d-datakey="data" d-datatype="object" d-dataproperty-agree="false"></div>
+            <div d-datakey="click" d-datatype="value" d-dataloadtype="startup" d-datavalue="ShowWindow(~/DrapoPages/WindowLoading.html,Windows,false)"></div>
+        </div>
+        <div>
+            <!--Validation-->
+            <div d-validation-id="agree" d-validation-type="conditional" d-validation-value="{{data.agree}}"></div>
+        </div>
+        <div>
+            <!--Svg with a bare 'd' attribute (regression: must not crash the validator)-->
+            <svg width="10" height="10"><path d="M10 10 H 90 V 90 H 10 Z" fill="none"></path></svg>
+            <div d-foo="x" data-end="123"></div>
+        </div>
+        <div>
+            <!--UI-->
+            <input type="checkbox" d-model="{{data.agree}}" /><span>Agree</span>
+            <div d-validation="agree" class="validatorInvalid">
+                <span>You must check the agree checkbox</span>
+            </div>
+            <br />
+            <br />
+            <input type="button" value="Validate" d-on-click="{{click}}" d-validation-on-click="agree" d-id="__drapoUnitTest" />
+        </div>
+    </div>
+
+</body></html>

--- a/src/Test/WebDrapo.Test/Pages/ValidationSvgWidget.Test.html
+++ b/src/Test/WebDrapo.Test/Pages/ValidationSvgWidget.Test.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml"><head>
+    <script src="/drapo.js"></script>
+    <link href="../css/validation.css" rel="stylesheet" />
+    <title>Validation Svg Widget</title>
+</head>
+<body>
+    <div d-id="Windows" d-sector="@" d-on-body-keyup-escape="CloseWindow()"></div>
+    <br />
+    <span>Validation Svg Widget</span>
+    <div class="" d-cloak="cloak">
+        <div>
+            <!--Data-->
+            <div d-datakey="data" d-datatype="object" d-dataproperty-text="value" d-dataproperty-text2="valu"></div>
+            <div d-datakey="click" d-datatype="value" d-dataloadtype="startup" d-datavalue="ShowWindow(~/DrapoPages/WindowLoading.html,Windows,false)"></div>
+        </div>
+        <div>
+            <!--Validation-->
+            <div d-validation-id="compare" d-validation-type="compare" d-validation-value="{{data.text2}}" d-validation-valuetocompare="{{data.text}}"></div>
+            <div d-validation-id="compare2" d-validation-type="compare" d-validation-value="{{data.text}}" d-validation-valuetocompare="{{data.text2}}"></div>
+        </div>
+        <div>
+            <!--Third-party widget markup (e.g. Google Maps markers/controls): several svg with bare 'd' attributes-->
+            <svg width="10" height="10"><path d="M10 10 H 90 V 90 H 10 Z" fill="none"></path></svg>
+            <div data-end="123" d-foo="x">
+                <svg width="10" height="10"><path d="M0 0 L 10 10" fill="none"></path><path d="M5 5 L 15 15" fill="none"></path></svg>
+            </div>
+        </div>
+        <div>
+            <!--UI-->
+            <span>Value 1: </span><input type="text" d-model="{{data.text}}" />
+            <br />
+            <span>Value 2: </span><input type="text" d-model="{{data.text2}}" />
+            <div d-validation="compare" class="validatorInvalid">
+                <span>You must fill the same value</span>
+            </div>
+            <div d-validation="compare2" class="validatorInvalid">
+                <span>You must fill the same value</span>
+            </div>
+            <br />
+            <br />
+            <input type="button" value="Validate" d-on-click="{{click}}" d-validation-on-click="{compare,compare2}" d-id="__drapoUnitTest" />
+        </div>
+    </div>
+
+</body></html>

--- a/src/Test/WebDrapo.Test/ReleaseTest.cs
+++ b/src/Test/WebDrapo.Test/ReleaseTest.cs
@@ -1791,6 +1791,16 @@ namespace WebDrapo.Test
             ValidatePage("ValidationEventCompare");
         }
         [TestCase]
+        public void ValidationSvgPathTest()
+        {
+            ValidatePage("ValidationSvgPath");
+        }
+        [TestCase]
+        public void ValidationSvgWidgetTest()
+        {
+            ValidatePage("ValidationSvgWidget");
+        }
+        [TestCase]
         public void ValidationEventConditionalTest()
         {
             ValidatePage("ValidationEventConditional");

--- a/src/Web/WebDrapo/wwwroot/DrapoPages/ValidationSvgPath.html
+++ b/src/Web/WebDrapo/wwwroot/DrapoPages/ValidationSvgPath.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="/drapo.js"></script>
+    <link href="../css/validation.css" rel="stylesheet" />
+    <title>Validation Svg Path</title>
+</head>
+<body>
+    <div d-id="Windows" d-sector="sector" d-on-body-keyup-escape="CloseWindow()"></div>
+    <br />
+    <span>Validation Svg Path</span>
+    <div class="cloak" d-cloak="cloak">
+        <div>
+            <!--Data-->
+            <div d-dataKey="data" d-dataType="object" d-dataProperty-agree="false"></div>
+            <div d-dataKey="click" d-datatype="value" d-dataloadtype="startup" d-dataValue="ShowWindow(~/DrapoPages/WindowLoading.html,Windows,false)"></div>
+        </div>
+        <div>
+            <!--Validation-->
+            <div d-validation-id="agree" d-validation-type="conditional" d-validation-value="{{data.agree}}"></div>
+        </div>
+        <div>
+            <!--Svg with a bare 'd' attribute (regression: must not crash the validator)-->
+            <svg width="10" height="10"><path d="M10 10 H 90 V 90 H 10 Z" fill="none"></path></svg>
+            <div d-foo="x" data-end="123"></div>
+        </div>
+        <div>
+            <!--UI-->
+            <input type="checkbox" d-model="{{data.agree}}" /><span>Agree</span>
+            <div d-validation="agree">
+                <span>You must check the agree checkbox</span>
+            </div>
+            <br />
+            <br />
+            <input type="button" value="Validate" d-on-click="{{click}}" d-validation-on-click="agree" d-id="__drapoUnitTest" />
+        </div>
+    </div>
+</body>
+</html>

--- a/src/Web/WebDrapo/wwwroot/DrapoPages/ValidationSvgWidget.html
+++ b/src/Web/WebDrapo/wwwroot/DrapoPages/ValidationSvgWidget.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="/drapo.js"></script>
+    <link href="../css/validation.css" rel="stylesheet" />
+    <title>Validation Svg Widget</title>
+</head>
+<body>
+    <div d-id="Windows" d-sector="sector" d-on-body-keyup-escape="CloseWindow()"></div>
+    <br />
+    <span>Validation Svg Widget</span>
+    <div class="cloak" d-cloak="cloak">
+        <div>
+            <!--Data-->
+            <div d-dataKey="data" d-dataType="object" d-dataProperty-text="value" d-dataProperty-text2="valu"></div>
+            <div d-dataKey="click" d-datatype="value" d-dataloadtype="startup" d-dataValue="ShowWindow(~/DrapoPages/WindowLoading.html,Windows,false)"></div>
+        </div>
+        <div>
+            <!--Validation-->
+            <div d-validation-id="compare" d-validation-type="compare" d-validation-value="{{data.text2}}" d-validation-valuetocompare="{{data.text}}"></div>
+            <div d-validation-id="compare2" d-validation-type="compare" d-validation-value="{{data.text}}" d-validation-valuetocompare="{{data.text2}}"></div>
+        </div>
+        <div>
+            <!--Third-party widget markup (e.g. Google Maps markers/controls): several svg with bare 'd' attributes-->
+            <svg width="10" height="10"><path d="M10 10 H 90 V 90 H 10 Z" fill="none"></path></svg>
+            <div data-end="123" d-foo="x">
+                <svg width="10" height="10"><path d="M0 0 L 10 10" fill="none"></path><path d="M5 5 L 15 15" fill="none"></path></svg>
+            </div>
+        </div>
+        <div>
+            <!--UI-->
+            <span>Value 1: </span><input type="text" d-model="{{data.text}}" />
+            <br />
+            <span>Value 2: </span><input type="text" d-model="{{data.text2}}" />
+            <div d-validation="compare">
+                <span>You must fill the same value</span>
+            </div>
+            <div d-validation="compare2">
+                <span>You must fill the same value</span>
+            </div>
+            <br />
+            <br />
+            <input type="button" value="Validate" d-on-click="{{click}}" d-validation-on-click="{compare,compare2}" d-id="__drapoUnitTest" />
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Problem

Loading any page that contains an SVG — or any element with an attribute named exactly `d` (e.g. `<path d="...">`) — threw on OnLoad and aborted **all** validation registration for the page:

```
Drapo - OnLoad - Stack: TypeError: Cannot read properties of undefined (reading 'toLowerCase')
    at DrapoValidator.ExtractValidationProperty (drapo.js:19781:22)
    at DrapoValidator.ExtractValidations (drapo.js:19771:44)
    at DrapoValidator.RegisterValidation (drapo.js:19585:34)
    at DrapoBarber.ResolveMustachesInternal (drapo.js:576:46)
```

### Root cause

`ExtractValidations` iterates **every attribute of every element** and calls `ExtractValidationProperty(nodeName)` on each. `ParseProperty(name)` is `name.split('-')`. For an attribute named exactly `d`, `'d'.split('-')` returns `['d']` (length 1):

```js
const parse = this.Application.Parser.ParseProperty(property); // ['d']
if (parse[0] != 'd')               // passes
    return (null);
if (parse[1].toLowerCase() != ...) // parse[1] is undefined -> TypeError
```

Any SVG on the page (Google Maps markers/controls, inline icons, Google Translate widget, etc.) triggers the crash, and because it throws during the OnLoad barber pass, **the whole page's validations stop being registered**.

## Fix

Add a length guard before accessing `parse[1]` in `DrapoValidator.ExtractValidationProperty`:

```ts
if (parse[0] != 'd' || parse.length < 2) // bare 'd' (e.g. SVG <path d="...">) is not a validation
    return (null);
```

Bare `d`, `data-*` and any non-`d-validation*` attribute are now ignored without throwing; `d-validation` and `d-validation-<x>` keep being extracted unchanged.

## Before / After

Page `ValidationSvgPath.html` (an SVG `<path d>` next to a real `d-validation`):

| Before fix | After fix |
|---|---|
| ![before](https://raw.githubusercontent.com/jmoreirat6/drapo/media/svg-fix-evidence/.github/prompts/svg-fix-evidence/before-fix.png) | ![after](https://raw.githubusercontent.com/jmoreirat6/drapo/media/svg-fix-evidence/.github/prompts/svg-fix-evidence/after-fix.png) |
| Console throws `TypeError ... toLowerCase`; the `d-cloak` never lifts so the form never renders | Console clean; the checkbox, validation message and Validate button render and the validation is registered |

<details>
<summary>Browser console — <b>before</b> fix (TypeError)</summary>

```
[Info] drapo.js "Drapo - OnLoad - Stack: TypeError: Cannot read properties of undefined (reading 'toLowerCase')
    at DrapoValidator.ExtractValidationProperty (drapo.js:19781:22)
    at DrapoValidator.ExtractValidations (drapo.js:19771:44)
    at DrapoValidator.RegisterValidation (drapo.js:19585:34)
    at DrapoBarber.ResolveMustachesInternal (drapo.js:576:46)
    at async DrapoBarber.ResolveMustachesInternal (drapo.js:551:21)
    at async DrapoBarber.ResolveMustaches (drapo.js:524:9)"
```
</details>

<details>
<summary>Browser console — <b>after</b> fix (clean)</summary>

```
[Info] drapo.js "[Information] WebSocket connected to ws://localhost:9991/drapoHub."
```
(no TypeError)
</details>

## Tests

Two Selenium/NUnit regression tests (the repo's native mechanism), with served pages under `wwwroot/DrapoPages/` and expected fixtures under `Test/WebDrapo.Test/Pages/`:

- **`ValidationSvgPathTest`** — SVG `<path d>` + `data-end` + `d-foo` alongside a real `d-validation`. Fails pre-fix (the throw aborts registration, so the form never renders); passes post-fix.
- **`ValidationSvgWidgetTest`** — multiple SVGs (Google-Maps-style markers) interleaved with two real validations; completes with no `TypeError` and all validations registered.

### Validation run (.NET 10, local WebDrapo on :9991)

```
dotnet test --filter "Name~Validation"
Passed!  - Failed: 0, Passed: 19, Skipped: 0, Total: 19
```

All 19 `Validation*` tests pass, including the 2 new ones — no regression.
