### PR TITLE
feat(query): support SUM and AVG aggregate functions

### DIFF
--- a/src/Middleware/Drapo/ts/DrapoStorage.ts
+++ b/src/Middleware/Drapo/ts/DrapoStorage.ts
@@ -2494,7 +2494,53 @@ class DrapoStorage {
             objectAggregation[query.Projections[0].Alias] = this.ResolveQueryAggregationsMin(query, query.Projections[0], objects, objectsInformation);
             return (objectAggregation);
         }
+        if (query.Projections[0].FunctionName === 'SUM') {
+            const objectAggregation: any = {};
+            objectAggregation[query.Projections[0].Alias] = this.ResolveQueryAggregationsSum(query, query.Projections[0], objects, objectsInformation);
+            return (objectAggregation);
+        }
+        if (query.Projections[0].FunctionName === 'AVG') {
+            const objectAggregation: any = {};
+            objectAggregation[query.Projections[0].Alias] = this.ResolveQueryAggregationsAvg(query, query.Projections[0], objects, objectsInformation);
+            return (objectAggregation);
+        }
         return (null);
+    }
+
+    private ResolveQueryAggregationsSum(query: DrapoQuery, projection: DrapoQueryProjection, objects: any[], objectsInformation: any[]): string {
+        let sum: number = 0;
+        let hasValue: boolean = false;
+        const functionParameter: string = projection.FunctionParameters[0];
+        const functionParameterName: string = this.ResolveQueryFunctionParameterName(functionParameter);
+        for (let i: number = 0; i < objectsInformation.length; i++) {
+            const valueCurrent: any = objectsInformation[i][functionParameterName];
+            if (valueCurrent == null)
+                continue;
+            const valueNumber: number = Number(valueCurrent);
+            if (isNaN(valueNumber))
+                continue;
+            sum += valueNumber;
+            hasValue = true;
+        }
+        return (hasValue ? this.Application.Solver.EnsureString(sum) : null);
+    }
+
+    private ResolveQueryAggregationsAvg(query: DrapoQuery, projection: DrapoQueryProjection, objects: any[], objectsInformation: any[]): string {
+        let sum: number = 0;
+        let count: number = 0;
+        const functionParameter: string = projection.FunctionParameters[0];
+        const functionParameterName: string = this.ResolveQueryFunctionParameterName(functionParameter);
+        for (let i: number = 0; i < objectsInformation.length; i++) {
+            const valueCurrent: any = objectsInformation[i][functionParameterName];
+            if (valueCurrent == null)
+                continue;
+            const valueNumber: number = Number(valueCurrent);
+            if (isNaN(valueNumber))
+                continue;
+            sum += valueNumber;
+            count++;
+        }
+        return (count > 0 ? this.Application.Solver.EnsureString(sum / count) : null);
     }
 
     private ResolveQueryAggregationsMax(query: DrapoQuery, projection: DrapoQueryProjection, objects: any[], objectsInformation: any[]): string {


### PR DESCRIPTION
## Problem
The client-side query engine (`d-dataType="query"`) supports **COUNT**, **MAX** and **MIN**, but **not SUM or AVG**. `DrapoStorage.ResolveQueryAggregations` only branches on `COUNT`/`MAX`/`MIN`; any other aggregate falls through to `return null`, so the query is treated as a normal projection and yields an **empty result** instead of the aggregate. The parser/validator accepts `Sum(...)` syntax, which makes the silent-empty result especially confusing.

### Repro
```html
<div d-dataKey='total' d-dataType='query'
     d-dataValue='SELECT Sum(Cells.[3].Value) AS Total FROM {{source.Rows}}'></div>
<span d-model='{{total.Total}}'></span>   <!-- renders empty (Count in the same spot works) -->
```

## Change
Add `ResolveQueryAggregationsSum` and `ResolveQueryAggregationsAvg` (mirroring the existing MIN/MAX helpers; accumulate numeric projection values, null/non-numeric skipped) and route `SUM`/`AVG` projections to them. Result is the usual single-object aggregate `{ Alias: value }`, reactive like the others.

- `SUM` -> numeric total (or null when no numeric values)
- `AVG` -> sum / count of numeric values (or null)

## Notes
- TS only (`src/Middleware/Drapo/ts/DrapoStorage.ts`). **Needs a JS rebuild (`lib/drapo.js`) + NuGet package bump** for consumers to pick it up.
- Surfaced while building a conversational data-form designer that binds a column total into a summary card via a reactive query data key — SUM is the most common card metric, so this was a notable gap.

## Test
Existing COUNT/MAX/MIN aggregate queries unchanged; new SUM/AVG follow the identical resolution path.