### PR TITLE
fix(query): resolve nested/positional column paths in aggregate functions

### DIFF
--- a/src/Middleware/Drapo/ts/DrapoStorage.ts
+++ b/src/Middleware/Drapo/ts/DrapoStorage.ts
@@ -2420,7 +2420,21 @@ class DrapoStorage {
                     }
                     if ((query.Sources.length > 1) && ((querySource.Alias ?? querySource.Source) !== source))
                         continue;
-                    const value: any = isObject ? sourceObject[projection.Column ?? property] : sourceObject;
+                    // Resolve the parameter as a data path so nested / positional columns (e.g. Cells.[3].Value)
+                    // aggregate correctly — not only flat top-level columns. Falls back to the flat lookup.
+                    let value: any;
+                    if (isObject) {
+                        let columnPath: string = functionParameter;
+                        const aliasPrefix: string = (querySource.Alias ?? querySource.Source) + '.';
+                        if ((query.Sources.length > 1) && (columnPath.indexOf(aliasPrefix) === 0))
+                            columnPath = columnPath.substring(aliasPrefix.length);
+                        if (columnPath.indexOf('.') >= 0)
+                            value = this.Application.Solver.ResolveDataObjectPathObject(sourceObject, [''].concat(columnPath.split('.')));
+                        else
+                            value = sourceObject[projection.Column ?? property];
+                    } else {
+                        value = sourceObject;
+                    }
                     objectInformation[functionParameterName] = value;
                 }
             } else {


### PR DESCRIPTION
## Problem
Follow-up to #659 (SUM/AVG). Even with SUM/AVG implemented, an aggregate over a **nested or positional column** still comes out **empty**. In `InjectQueryObjectProjections` the function-parameter value is read from the source row with a **flat** lookup:
```ts
const value = isObject ? sourceObject[projection.Column ?? property] : sourceObject;
```
So a column like `Cells.[3].Value` never resolves — `objectInformation` gets `undefined`, and SUM/AVG/MAX/MIN have nothing to aggregate. (COUNT was unaffected because it ignores the column value.)

### Repro
```html
<!-- worksheet rows: row.Cells.[3].Value is the numeric amount -->
<div d-dataKey='total' d-dataType='query'
     d-dataValue='SELECT Sum(Cells.[3].Value) AS Total FROM {{source.Rows}}'></div>
<span d-model='{{total.Total}}' d-format='N2'></span>   <!-- empty before this fix -->
```

## Change
Resolve the parameter as a **data path** via `Solver.ResolveDataObjectPathObject` (which already handles `[n]` indexers), stripping a leading source alias for multi-source queries, and fall back to the flat lookup for simple top-level columns. This makes SUM/AVG/MAX/MIN work over nested object arrays (e.g. worksheet `row.Cells.[N].Value`) while leaving flat-column behavior unchanged.

## Verification
Built the engine locally with #659 + this change, embedded into the middleware DLL, and ran it in a real app: a `SELECT Sum(Cells.[3].Value)` query bound into a summary card went from **empty → a live, reactive column total** (re-computes on row edits), matching the worksheet's data source row count.

## Notes
TS only; needs a JS rebuild (`lib/drapo.js`) + NuGet bump to reach consumers. Pairs with docs issue spadrapo/docs#362.