### PR TITLE
feat(async): timespan defer for Async + focus preservation across re-render

### DIFF
--- a/src/Middleware/Drapo/ts/DrapoControlFlow.ts
+++ b/src/Middleware/Drapo/ts/DrapoControlFlow.ts
@@ -132,6 +132,25 @@ class DrapoControlFlow {
     }
 
     private async ResolveControlFlowForInternal(sector: string, context: DrapoContext, renderContext: DrapoRenderContext, elFor: HTMLElement, isIncremental: boolean, canUseDifference: boolean = true, type: DrapoStorageLinkType = DrapoStorageLinkType.Render): Promise<boolean> {
+        //Preserve focus across the rebuild. If this d-for recreates the element that currently holds focus, the node
+        //is detached by the render; we snapshot it (by d-id, with caret) before and restore focus to the new node
+        //after. The detached check scopes this to the d-for that actually owns the focused element - when focus must
+        //survive a Tab (activeElement is the page body during the blur), defer the notify with Async(Notify(...),0)
+        //so this runs after the browser has settled focus on the target field, which is then inside this rebuild.
+        const focusedElement: HTMLElement = document.activeElement as HTMLElement;
+        const focusState: [string, number, number] = this.Application.Document.GetFocusStateForElement(focusedElement);
+        //The container that holds this loop's rendered rows; the recreated node is relocated within it (never globally).
+        const focusScope: HTMLElement = (focusState != null) ? elFor.parentElement : null;
+        try {
+            return (await this.ResolveControlFlowForInternalCore(sector, context, renderContext, elFor, isIncremental, canUseDifference, type));
+        } finally {
+            const active: Element = document.activeElement;
+            if ((focusState != null) && (!this.Application.Document.IsElementAttached(focusedElement)) && ((active == null) || (active === document.body)))
+                this.Application.Document.RestoreFocusState(focusState, focusScope);
+        }
+    }
+
+    private async ResolveControlFlowForInternalCore(sector: string, context: DrapoContext, renderContext: DrapoRenderContext, elFor: HTMLElement, isIncremental: boolean, canUseDifference: boolean = true, type: DrapoStorageLinkType = DrapoStorageLinkType.Render): Promise<boolean> {
         let forText: string = elFor.getAttribute('d-for');
         let ifText: string = null;
         let forIfText: string = null;

--- a/src/Middleware/Drapo/ts/DrapoDocument.ts
+++ b/src/Middleware/Drapo/ts/DrapoDocument.ts
@@ -904,6 +904,56 @@ class DrapoDocument {
             eli.value = value;
     }
 
+    public IsElementSelectable(el: HTMLElement): boolean {
+        const tag: string = el.tagName.toLowerCase();
+        if (tag === 'textarea')
+            return (true);
+        if (tag !== 'input')
+            return (false);
+        const typeAttribute: string = el.getAttribute('type');
+        const type: string = (typeAttribute == null) ? 'text' : typeAttribute.toLowerCase();
+        return ((type === 'text') || (type === 'search') || (type === 'password') || (type === 'tel') || (type === 'url'));
+    }
+
+    public GetFocusStateForElement(el: HTMLElement): [string, number, number] {
+        if ((el == null) || (el === document.body) || (el.getAttribute == null))
+            return (null);
+        const tag: string = el.tagName.toLowerCase();
+        if ((tag !== 'input') && (tag !== 'textarea') && (tag !== 'select'))
+            return (null);
+        //We can only relocate the element after a re-render when it has a stable d-id
+        const did: string = el.getAttribute('d-id');
+        if (did == null)
+            return (null);
+        let start: number = null;
+        let end: number = null;
+        if (this.IsElementSelectable(el)) {
+            const input: HTMLInputElement = el as HTMLInputElement;
+            start = input.selectionStart;
+            end = input.selectionEnd;
+        }
+        return ([did, start, end]);
+    }
+
+    public RestoreFocusState(state: [string, number, number], scope: HTMLElement): void {
+        if ((state == null) || (scope == null))
+            return;
+        const did: string = state[0];
+        //The focused node was recreated by the render, so relocate it by its d-id and restore focus and caret.
+        //Search only inside the container that was rebuilt, so a duplicate d-id elsewhere on the page is never matched.
+        const target: HTMLElement = this.Application.Searcher.FindByAttributeAndValueFromParent('d-id', did, scope);
+        if (target == null)
+            return;
+        target.focus();
+        const start: number = state[1];
+        const end: number = state[2];
+        if ((start != null) && (end != null) && (this.IsElementSelectable(target))) {
+            const input: HTMLInputElement = target as HTMLInputElement;
+            if (input.setSelectionRange != null)
+                input.setSelectionRange(start, end);
+        }
+    }
+
     public GetText(el: HTMLElement): string {
         if (el.children.length > 0)
             return ('');

--- a/src/Middleware/Drapo/ts/DrapoFunctionHandler.ts
+++ b/src/Middleware/Drapo/ts/DrapoFunctionHandler.ts
@@ -1192,8 +1192,19 @@ class DrapoFunctionHandler {
     private async ExecuteFunctionAsync(sector: string, contextItem: DrapoContextItem, element: HTMLElement, event: Event, functionParsed: DrapoFunction, executionContext: DrapoExecutionContext<any>): Promise<string> {
         const content: string = functionParsed.Parameters[0];
         const executionContextContent: DrapoExecutionContext<any> = this.CreateExecutionContext(false);
-        // tslint:disable-next-line:no-floating-promises
-        this.ResolveFunctionContext(sector, contextItem, element, event, content, executionContextContent);
+        //An optional timespan (ms) defers the content to a macrotask via setTimeout instead of the default microtask,
+        //so it runs after the current task completes (e.g. after the browser settles a Tab focus change).
+        const timespanText: string = functionParsed.Parameters.length > 1 ? await this.ResolveFunctionParameter(sector, contextItem, element, executionContext, functionParsed.Parameters[1]) : null;
+        if ((timespanText !== null) && (timespanText !== '')) {
+            const timespan: number = this.Application.Parser.GetStringAsNumber(timespanText);
+            setTimeout(() => {
+                // tslint:disable-next-line:no-floating-promises
+                this.ResolveFunctionContext(sector, contextItem, element, event, content, executionContextContent);
+            }, timespan);
+        } else {
+            // tslint:disable-next-line:no-floating-promises
+            this.ResolveFunctionContext(sector, contextItem, element, event, content, executionContextContent);
+        }
         return ('');
     }
 

--- a/src/Test/WebDrapo.Test/ReleaseTest.cs
+++ b/src/Test/WebDrapo.Test/ReleaseTest.cs
@@ -1375,6 +1375,84 @@ namespace WebDrapo.Test
             ValidatePage("FunctionFocus");
         }
         [TestCase]
+        public void ModelChangeUpdateItemFieldFocusTest()
+        {
+            // Regression: a model change that rebuilds the d-for rows used to steal focus from the field the
+            // user tabbed into. The handler updates data synchronously then defers the re-render with
+            // Async(Notify(...),0); the deferred notify snapshots and restores the focused element.
+            string pageUrl = string.Format("{0}DrapoPages/{1}.html", VirtualDirectory, "Bug_ModelChangeUpdateItemFieldFocus");
+            Driver.Navigate().GoToUrl(pageUrl);
+            IJavaScriptExecutor js = (IJavaScriptExecutor)Driver;
+            for (int i = 0; i < 20; i++)
+            {
+                bool loaded = (bool)js.ExecuteScript("return(drapo._isLoaded);");
+                if (loaded)
+                    break;
+                System.Threading.Thread.Sleep(100);
+            }
+            // Type a percentage into April and Tab to May. The blur fires d-on-model-change, which
+            // calls UpdateItemField(notify=true) and re-renders the rows.
+            IWebElement april = Driver.FindElement(By.CssSelector("[d-id='perc3']"));
+            april.Click();
+            april.SendKeys("0.1");
+            april.SendKeys(Keys.Tab);
+            System.Threading.Thread.Sleep(1000);
+            // Focus must have moved to May (perc4) and stayed there instead of falling back to the body.
+            IWebElement active = Driver.SwitchTo().ActiveElement();
+            string activeDId = active.GetDomAttribute("d-id");
+            Assert.That(activeDId, Is.EqualTo("perc4"), "Focus should remain on the next field (May) after the model-change notify.");
+            // The calculated financial field must have been updated (proves the notify still happened).
+            IWebElement aprilValue = Driver.FindElement(By.CssSelector("[d-id='val3']"));
+            Assert.That(aprilValue.Text.Trim(), Is.Not.EqualTo("0"), "The calculated field must update after the model change.");
+        }
+        [TestCase]
+        public void ModelChangeFocusFunctionTest()
+        {
+            // When d-on-model-change defers an explicit Focus() with the notify (Async(Focus(...);Notify(...),0)),
+            // that focus must survive the re-render (here the handler focuses Jul / perc6).
+            string pageUrl = string.Format("{0}DrapoPages/{1}.html", VirtualDirectory, "Bug_ModelChangeFocusFunction");
+            Driver.Navigate().GoToUrl(pageUrl);
+            IJavaScriptExecutor js = (IJavaScriptExecutor)Driver;
+            for (int i = 0; i < 20; i++)
+            {
+                bool loaded = (bool)js.ExecuteScript("return(drapo._isLoaded);");
+                if (loaded)
+                    break;
+                System.Threading.Thread.Sleep(100);
+            }
+            IWebElement april = Driver.FindElement(By.CssSelector("[d-id='perc3']"));
+            april.Click();
+            april.SendKeys("0.1");
+            april.SendKeys(Keys.Tab);
+            System.Threading.Thread.Sleep(1000);
+            IWebElement active = Driver.SwitchTo().ActiveElement();
+            string activeDId = active.GetDomAttribute("d-id");
+            Assert.That(activeDId, Is.EqualTo("perc6"), "The explicit Focus() deferred with the notify must keep focus on its target.");
+        }
+        [TestCase]
+        public void FunctionAsyncTimespanTest()
+        {
+            // Async(content, timespan) must defer content to a macrotask (setTimeout), not run it synchronously.
+            string pageUrl = string.Format("{0}DrapoPages/{1}.html", VirtualDirectory, "FunctionAsyncTimespan");
+            Driver.Navigate().GoToUrl(pageUrl);
+            IJavaScriptExecutor js = (IJavaScriptExecutor)Driver;
+            for (int i = 0; i < 20; i++)
+            {
+                bool loaded = (bool)js.ExecuteScript("return(drapo._isLoaded);");
+                if (loaded)
+                    break;
+                System.Threading.Thread.Sleep(100);
+            }
+            IWebElement run = Driver.FindElement(By.CssSelector("[d-id='run']"));
+            IWebElement result = Driver.FindElement(By.CssSelector("[d-id='result']"));
+            run.Click();
+            // Immediately after the click the deferred UpdateDataField (timespan 800ms) has not run yet.
+            Assert.That(result.Text.Trim(), Is.EqualTo("EARLY"), "Async with a timespan must defer, not run synchronously.");
+            // After the timespan elapses it runs.
+            System.Threading.Thread.Sleep(1500);
+            Assert.That(result.Text.Trim(), Is.EqualTo("LATE"), "The deferred content must run after the timespan.");
+        }
+        [TestCase]
         public void FunctionGetSectorTest()
         {
             ValidatePage("FunctionGetSector");

--- a/src/Web/WebDrapo/wwwroot/DrapoPages/Bug_ModelChangeFocusFunction.html
+++ b/src/Web/WebDrapo/wwwroot/DrapoPages/Bug_ModelChangeFocusFunction.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="/drapo.js"></script>
+    <title>Bug - Model Change Focus Function</title>
+</head>
+<body>
+    <span>Bug - Model Change Focus Function</span>
+    <div d-datakey="total" d-datatype="value" d-datavalue="1000"></div>
+    <div d-datakey="months" d-datatype="array"
+         d-datavalue="[{&quot;Month&quot;:&quot;Jan&quot;,&quot;Perc&quot;:&quot;&quot;,&quot;Value&quot;:&quot;0&quot;},{&quot;Month&quot;:&quot;Feb&quot;,&quot;Perc&quot;:&quot;&quot;,&quot;Value&quot;:&quot;0&quot;},{&quot;Month&quot;:&quot;Mar&quot;,&quot;Perc&quot;:&quot;&quot;,&quot;Value&quot;:&quot;0&quot;},{&quot;Month&quot;:&quot;Apr&quot;,&quot;Perc&quot;:&quot;&quot;,&quot;Value&quot;:&quot;0&quot;},{&quot;Month&quot;:&quot;May&quot;,&quot;Perc&quot;:&quot;&quot;,&quot;Value&quot;:&quot;0&quot;},{&quot;Month&quot;:&quot;Jun&quot;,&quot;Perc&quot;:&quot;&quot;,&quot;Value&quot;:&quot;0&quot;},{&quot;Month&quot;:&quot;Jul&quot;,&quot;Perc&quot;:&quot;&quot;,&quot;Value&quot;:&quot;0&quot;},{&quot;Month&quot;:&quot;Aug&quot;,&quot;Perc&quot;:&quot;&quot;,&quot;Value&quot;:&quot;0&quot;}]"></div>
+    <div>
+        <div d-for="month in months" d-if="{{total}}>0">
+            <span>{{month.Month}}: </span>
+            <!-- Explicit Focus(perc6=Jul), deferred with the notify so it survives the rebuild -->
+            <input type="text" d-id="perc{{month._Index}}"
+                   d-model="{{month.Perc}}" d-model-event="blur" d-modelNotify="false"
+                   d-on-model-change="UpdateItemField({{month.Value}},Cast({{total}}*{{month.Perc}},number),false);Async(Focus(perc6);Notify(months),0)" />
+            <span d-id="val{{month._Index}}">{{month.Value}}</span>
+            <br />
+        </div>
+    </div>
+</body>
+</html>

--- a/src/Web/WebDrapo/wwwroot/DrapoPages/Bug_ModelChangeUpdateItemFieldFocus.html
+++ b/src/Web/WebDrapo/wwwroot/DrapoPages/Bug_ModelChangeUpdateItemFieldFocus.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="/drapo.js"></script>
+    <title>Bug - Model Change UpdateItemField Focus</title>
+</head>
+<body>
+    <span>Bug - Model Change UpdateItemField Focus</span>
+    <!-- Total investment -->
+    <div d-datakey="total" d-datatype="value" d-datavalue="1000"></div>
+    <!-- Twelve months, each with a percentage and a calculated financial value (customer repro).
+         The d-if on the row forces the full-rebuild render path. The model change updates the data
+         synchronously (UpdateItemField notify=false) and then defers ONLY the re-render with
+         Async(Notify(...),0); by the time the deferred notify rebuilds the rows the browser has settled
+         focus on the field being tabbed into, which the notify preserves. -->
+    <div d-datakey="months" d-datatype="array"
+         d-datavalue="[{&quot;Month&quot;:&quot;Jan&quot;,&quot;Perc&quot;:&quot;&quot;,&quot;Value&quot;:&quot;0&quot;},{&quot;Month&quot;:&quot;Feb&quot;,&quot;Perc&quot;:&quot;&quot;,&quot;Value&quot;:&quot;0&quot;},{&quot;Month&quot;:&quot;Mar&quot;,&quot;Perc&quot;:&quot;&quot;,&quot;Value&quot;:&quot;0&quot;},{&quot;Month&quot;:&quot;Apr&quot;,&quot;Perc&quot;:&quot;&quot;,&quot;Value&quot;:&quot;0&quot;},{&quot;Month&quot;:&quot;May&quot;,&quot;Perc&quot;:&quot;&quot;,&quot;Value&quot;:&quot;0&quot;},{&quot;Month&quot;:&quot;Jun&quot;,&quot;Perc&quot;:&quot;&quot;,&quot;Value&quot;:&quot;0&quot;},{&quot;Month&quot;:&quot;Jul&quot;,&quot;Perc&quot;:&quot;&quot;,&quot;Value&quot;:&quot;0&quot;},{&quot;Month&quot;:&quot;Aug&quot;,&quot;Perc&quot;:&quot;&quot;,&quot;Value&quot;:&quot;0&quot;},{&quot;Month&quot;:&quot;Sep&quot;,&quot;Perc&quot;:&quot;&quot;,&quot;Value&quot;:&quot;0&quot;},{&quot;Month&quot;:&quot;Oct&quot;,&quot;Perc&quot;:&quot;&quot;,&quot;Value&quot;:&quot;0&quot;},{&quot;Month&quot;:&quot;Nov&quot;,&quot;Perc&quot;:&quot;&quot;,&quot;Value&quot;:&quot;0&quot;},{&quot;Month&quot;:&quot;Dec&quot;,&quot;Perc&quot;:&quot;&quot;,&quot;Value&quot;:&quot;0&quot;}]"></div>
+    <div>
+        <div d-for="month in months" d-if="{{total}}>0">
+            <span>{{month.Month}}: </span>
+            <input type="text"
+                   d-id="perc{{month._Index}}"
+                   d-model="{{month.Perc}}"
+                   d-model-event="blur"
+                   d-modelNotify="false"
+                   d-on-model-change="UpdateItemField({{month.Value}},Cast({{total}}*{{month.Perc}},number),false);Async(Notify(months),0)" />
+            <span d-id="val{{month._Index}}">{{month.Value}}</span>
+            <br />
+        </div>
+    </div>
+</body>
+</html>

--- a/src/Web/WebDrapo/wwwroot/DrapoPages/FunctionAsyncTimespan.html
+++ b/src/Web/WebDrapo/wwwroot/DrapoPages/FunctionAsyncTimespan.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="/drapo.js"></script>
+    <title>Function Async Timespan</title>
+</head>
+<body>
+    <span>Function Async Timespan</span>
+    <div d-datakey="state" d-datatype="object" d-dataproperty-value="EARLY"></div>
+    <input type="button" value="run" d-id="run"
+           d-on-click="Async(UpdateDataField(state,value,LATE),800)" />
+    <span d-id="result" d-model="{{state.value}}"></span>
+</body>
+</html>


### PR DESCRIPTION
## Problem

A field using `d-on-model-change` with `UpdateItemField` that notifies (re-renders) **loses focus on the field the user is tabbing into**. The `d-for`/component rebuild recreates the focused input while the browser has not yet settled focus on the next field, so focus falls to `<body>`. Setting the notify flag to `false` keeps focus but the calculated field never updates — forcing a choice between a working calc and working Tab navigation.

## Approach (minimal core, opt-in)

Two small, composable additions:

1. **`Async(content, timespan)`** — an optional `timespan` (ms) second parameter defers `content` to a **macrotask** (`setTimeout`) instead of the default microtask. Deferring a notify lets it run *after* the browser settles a Tab focus change. (`DrapoFunctionHandler`)

2. **Focus preservation at the source of the churn** — `DrapoControlFlow.ResolveControlFlowForInternal` snapshots the focused element (by `d-id`, incl. caret) before the rebuild and, **only if the rebuild detaches it**, restores focus to the recreated node (synchronous). The detached check scopes it to the `d-for` that actually owns the focused element — no per-notify work, no broad capture. (`DrapoControlFlow` + `DrapoDocument` helpers)

`DrapoObserver` and `DrapoBinder` are untouched (reverted to `master`). Footprint is 3 runtime files: `DrapoControlFlow`, `DrapoDocument`, `DrapoFunctionHandler`.

## Usage

Update the data synchronously and defer only the re-render:

```
UpdateItemField({{cell.Value}}, Cast(...), false); Async(Notify(dataKey), 0)
```

By the time the deferred notify rebuilds the rows, the browser has settled focus on the tabbed-to field, which the control-flow rebuild snapshots and restores — so focus is kept **and** the calc updates. An explicit `Focus()` is deferred the same way: `Async(Focus(target); Notify(dataKey), 0)`.

## Tests

- `ModelChangeUpdateItemFieldFocusTest` — tab keeps focus on the next field; calc updates.
- `ModelChangeFocusFunctionTest` — a deferred explicit `Focus()` keeps its target.
- `FunctionAsyncTimespanTest` — `Async(content, timespan)` defers (EARLY → LATE).

New DrapoPages: `Bug_ModelChangeUpdateItemFieldFocus.html`, `Bug_ModelChangeFocusFunction.html`, `FunctionAsyncTimespan.html`.

## Verification

- `tslint --project tsconfig/production/` → pass · `dotnet build Drapo.sln` → 0 errors
- New tests stable across repeated runs. The focus logic is a **no-op when nothing is focused** (`focusState` null → render output byte-identical), so render-comparison tests are unaffected. Full suite shows only pre-existing parallel-load timing flakes (different tests per run, all pass in isolation) — no regressions.

Docs (Async `timespan` param + the focus-preservation pattern + Events guide) in companion **spadrapo/docs#381**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)