### PR TITLE
fix(673): resolve function expressions against the event row and restore focus without d-id

### DIFF
--- a/src/Middleware/Drapo/ts/DrapoControlFlow.ts
+++ b/src/Middleware/Drapo/ts/DrapoControlFlow.ts
@@ -138,9 +138,9 @@ class DrapoControlFlow {
         //survive a Tab (activeElement is the page body during the blur), defer the notify with Async(Notify(...),0)
         //so this runs after the browser has settled focus on the target field, which is then inside this rebuild.
         const focusedElement: HTMLElement = document.activeElement as HTMLElement;
-        const focusState: [string, number, number] = this.Application.Document.GetFocusStateForElement(focusedElement);
         //The container that holds this loop's rendered rows; the recreated node is relocated within it (never globally).
-        const focusScope: HTMLElement = (focusState != null) ? elFor.parentElement : null;
+        const focusScope: HTMLElement = elFor.parentElement;
+        const focusState: [string, number, number, number] = this.Application.Document.GetFocusStateForElement(focusedElement, focusScope);
         try {
             return (await this.ResolveControlFlowForInternalCore(sector, context, renderContext, elFor, isIncremental, canUseDifference, type));
         } finally {

--- a/src/Middleware/Drapo/ts/DrapoDocument.ts
+++ b/src/Middleware/Drapo/ts/DrapoDocument.ts
@@ -915,15 +915,32 @@ class DrapoDocument {
         return ((type === 'text') || (type === 'search') || (type === 'password') || (type === 'tel') || (type === 'url'));
     }
 
-    public GetFocusStateForElement(el: HTMLElement): [string, number, number] {
+    private GetFocusableElements(scope: HTMLElement): HTMLElement[] {
+        const nodes: NodeListOf<Element> = scope.querySelectorAll('input, textarea, select');
+        const elements: HTMLElement[] = [];
+        for (let i: number = 0; i < nodes.length; i++)
+            elements.push(nodes[i] as HTMLElement);
+        return (elements);
+    }
+
+    public GetFocusStateForElement(el: HTMLElement, scope: HTMLElement): [string, number, number, number] {
         if ((el == null) || (el === document.body) || (el.getAttribute == null))
             return (null);
         const tag: string = el.tagName.toLowerCase();
         if ((tag !== 'input') && (tag !== 'textarea') && (tag !== 'select'))
             return (null);
-        //We can only relocate the element after a re-render when it has a stable d-id
+        //Relocate the element after a re-render by its stable d-id when it has one; otherwise fall back to its
+        //structural position among the focusable elements of the rebuilt scope (elements without d-id, like the
+        //inner input of a component or a plain input inside a d-for row).
         const did: string = el.getAttribute('d-id');
-        if (did == null)
+        let position: number = null;
+        if ((did == null) && (scope != null) && (scope.contains(el))) {
+            const focusables: HTMLElement[] = this.GetFocusableElements(scope);
+            const index: number = focusables.indexOf(el);
+            if (index >= 0)
+                position = index;
+        }
+        if ((did == null) && (position == null))
             return (null);
         let start: number = null;
         let end: number = null;
@@ -932,21 +949,29 @@ class DrapoDocument {
             start = input.selectionStart;
             end = input.selectionEnd;
         }
-        return ([did, start, end]);
+        return ([did, position, start, end]);
     }
 
-    public RestoreFocusState(state: [string, number, number], scope: HTMLElement): void {
+    public RestoreFocusState(state: [string, number, number, number], scope: HTMLElement): void {
         if ((state == null) || (scope == null))
             return;
         const did: string = state[0];
-        //The focused node was recreated by the render, so relocate it by its d-id and restore focus and caret.
+        const position: number = state[1];
+        //The focused node was recreated by the render, so relocate it and restore focus and caret.
         //Search only inside the container that was rebuilt, so a duplicate d-id elsewhere on the page is never matched.
-        const target: HTMLElement = this.Application.Searcher.FindByAttributeAndValueFromParent('d-id', did, scope);
+        let target: HTMLElement = null;
+        if (did != null) {
+            target = this.Application.Searcher.FindByAttributeAndValueFromParent('d-id', did, scope);
+        } else if (position != null) {
+            const focusables: HTMLElement[] = this.GetFocusableElements(scope);
+            if (position < focusables.length)
+                target = focusables[position];
+        }
         if (target == null)
             return;
         target.focus();
-        const start: number = state[1];
-        const end: number = state[2];
+        const start: number = state[2];
+        const end: number = state[3];
         if ((start != null) && (end != null) && (this.IsElementSelectable(target))) {
             const input: HTMLInputElement = target as HTMLInputElement;
             if (input.setSelectionRange != null)

--- a/src/Middleware/Drapo/ts/DrapoDocument.ts
+++ b/src/Middleware/Drapo/ts/DrapoDocument.ts
@@ -918,8 +918,19 @@ class DrapoDocument {
     private GetFocusableElements(scope: HTMLElement): HTMLElement[] {
         const nodes: NodeListOf<Element> = scope.querySelectorAll('input, textarea, select');
         const elements: HTMLElement[] = [];
-        for (let i: number = 0; i < nodes.length; i++)
-            elements.push(nodes[i] as HTMLElement);
+        for (let i: number = 0; i < nodes.length; i++) {
+            const el: HTMLElement = nodes[i] as HTMLElement;
+            //Skip elements that can not actually receive focus, so the positional snapshot stays
+            //stable when hidden or disabled controls exist in the rebuilt scope
+            const type: string = el.getAttribute('type');
+            if ((type != null) && (type.toLowerCase() === 'hidden'))
+                continue;
+            if ((el as HTMLInputElement).disabled)
+                continue;
+            if (el.getAttribute('tabindex') === '-1')
+                continue;
+            elements.push(el);
+        }
         return (elements);
     }
 

--- a/src/Middleware/Drapo/ts/DrapoFunctionHandler.ts
+++ b/src/Middleware/Drapo/ts/DrapoFunctionHandler.ts
@@ -142,6 +142,23 @@ class DrapoFunctionHandler {
         return (result);
     }
 
+    private async ResolveFunctionExpression(sector: string, contextItem: DrapoContextItem, executionContext: DrapoExecutionContext<any>, expression: string): Promise<string> {
+        //Replace inner function expressions first
+        const context: DrapoContext = contextItem != null ? contextItem.Context : new DrapoContext();
+        let resolved: string = await this.ReplaceFunctionExpressions(sector, context, expression, false);
+        //Resolve mustaches against the element's own context item. The shared context cursor (context.Item)
+        //is left pointing at the LAST iterated row after a render, so resolving through the context reads the
+        //wrong row when the function runs from an event raised on any other row.
+        const mustaches: string[] = this.Application.Parser.ParseMustaches(resolved);
+        for (let i: number = 0; i < mustaches.length; i++) {
+            const mustache: string = mustaches[i];
+            const mustacheParts: string[] = this.Application.Parser.ParseMustache(mustache);
+            const value: any = await this.Application.Solver.ResolveItemDataPathObject(sector, contextItem, mustacheParts, false, executionContext);
+            resolved = resolved.replace(mustache, this.Application.Solver.EnsureString(value));
+        }
+        return (resolved);
+    }
+
     public async ResolveFunctionParameter(sector: string, contextItem: DrapoContextItem, element: HTMLElement, executionContext: DrapoExecutionContext<any>, parameter: string, canForceLoadDataDelay: boolean = false, canUseReturnFunction: boolean = false, isRecursive: boolean = false): Promise<any> {
         //Function
         if (canUseReturnFunction) {
@@ -1482,8 +1499,7 @@ class DrapoFunctionHandler {
     }
 
     private async ExecuteFunctionCast(sector: string, contextItem: DrapoContextItem, element: HTMLElement, event: Event, functionParsed: DrapoFunction, executionContext: DrapoExecutionContext<any>): Promise<any> {
-        const context: DrapoContext = contextItem != null ? contextItem.Context : new DrapoContext();
-        const value: string = await this.Application.Barber.ResolveControlFlowMustacheStringFunction(sector, context, null, executionContext, functionParsed.Parameters[0], null, false);
+        const value: string = await this.ResolveFunctionExpression(sector, contextItem, executionContext, functionParsed.Parameters[0]);
         const type: string = await this.ResolveFunctionParameter(sector, contextItem, element, executionContext, functionParsed.Parameters[1]);
         if (type === 'number')
             return (this.Application.Parser.ParseNumberBlock(value));
@@ -1491,8 +1507,7 @@ class DrapoFunctionHandler {
     }
 
     private async ExecuteFunctionRound(sector: string, contextItem: DrapoContextItem, element: HTMLElement, event: Event, functionParsed: DrapoFunction, executionContext: DrapoExecutionContext<any>): Promise<any> {
-        const context: DrapoContext = contextItem != null ? contextItem.Context : new DrapoContext();
-        const valueResolved: string = await this.Application.Barber.ResolveControlFlowMustacheStringFunction(sector, context, null, executionContext, functionParsed.Parameters[0], null, false);
+        const valueResolved: string = await this.ResolveFunctionExpression(sector, contextItem, executionContext, functionParsed.Parameters[0]);
         const value: number = this.Application.Parser.ParseNumberBlock(valueResolved);
         const digitsParameter: string = functionParsed.Parameters.length > 1 ? await this.ResolveFunctionParameter(sector, contextItem, element, executionContext, functionParsed.Parameters[1]) : null;
         const digits: number = this.Application.Parser.ParseNumber(digitsParameter, 0);
@@ -1511,8 +1526,7 @@ class DrapoFunctionHandler {
     }
 
     private async ExecuteFunctionEncodeUrl(sector: string, contextItem: DrapoContextItem, element: HTMLElement, event: Event, functionParsed: DrapoFunction, executionContext: DrapoExecutionContext<any>): Promise<any> {
-        const context: DrapoContext = contextItem != null ? contextItem.Context : new DrapoContext();
-        const value: string = await this.Application.Barber.ResolveControlFlowMustacheStringFunction(sector, context, null, executionContext, functionParsed.Parameters[0], null, false);
+        const value: string = await this.ResolveFunctionExpression(sector, contextItem, executionContext, functionParsed.Parameters[0]);
         const valueEncoded: string = this.Application.Server.EnsureUrlComponentEncoded(value);
         return (valueEncoded);
     }

--- a/src/Middleware/Drapo/ts/DrapoFunctionHandler.ts
+++ b/src/Middleware/Drapo/ts/DrapoFunctionHandler.ts
@@ -46,11 +46,14 @@ class DrapoFunctionHandler {
         return (false);
     }
 
-    public async ReplaceFunctionExpressions(sector: string, context: DrapoContext, expression: string, canBind: boolean): Promise<string> {
-        return (await this.ReplaceFunctionExpressionsContext(sector, context, expression, canBind, this.CreateExecutionContext(false)));
+    public async ReplaceFunctionExpressions(sector: string, context: DrapoContext, expression: string, canBind: boolean, contextItem: DrapoContextItem = null): Promise<string> {
+        return (await this.ReplaceFunctionExpressionsContext(sector, context, expression, canBind, this.CreateExecutionContext(false), contextItem));
     }
 
-    public async ReplaceFunctionExpressionsContext(sector: string, context: DrapoContext, expression: string, canBind: boolean, executionContext: DrapoExecutionContext<any>): Promise<string> {
+    public async ReplaceFunctionExpressionsContext(sector: string, context: DrapoContext, expression: string, canBind: boolean, executionContext: DrapoExecutionContext<any>, contextItem: DrapoContextItem = null): Promise<string> {
+        //When the expression runs from an event raised on a specific element, that element's context item must
+        //win over the shared context cursor (context.Item), which is left pointing at the last iterated row.
+        const item: DrapoContextItem = (contextItem != null) ? contextItem : context.Item;
         //Parser
         const functionsParsed: string[] = this.Application.Parser.ParseFunctions(expression);
         for (let i = 0; i < functionsParsed.length; i++) {
@@ -61,11 +64,11 @@ class DrapoFunctionHandler {
             //Mustache
             if (this.Application.Parser.IsMustache(functionParse)) {
                 const dataPath: string[] = this.Application.Parser.ParseMustache(functionParse);
-                const data: string = await this.Application.Solver.ResolveItemDataPathObject(sector, context.Item, dataPath);
+                const data: string = await this.Application.Solver.ResolveItemDataPathObject(sector, item, dataPath);
                 if ((data == null) || (data == ''))
                     continue;
                 functionParse = data;
-                const functionInnerParsed = await this.ReplaceFunctionExpressionsContext(sector, context, functionParse, canBind, executionContext);
+                const functionInnerParsed = await this.ReplaceFunctionExpressionsContext(sector, context, functionParse, canBind, executionContext, contextItem);
                 if (functionInnerParsed === functionParse)
                     continue;
                 functionParse = functionInnerParsed;
@@ -77,7 +80,7 @@ class DrapoFunctionHandler {
                 await this.Application.ExceptionHandler.HandleError('DrapoFunctionHandler - ResolveFunction - Invalid Parse - {0}', functionParse);
                 continue;
             }
-            expression = expression.replace(functionParse, await this.ExecuteFunctionContextSwitch(sector, context.Item, null, null, functionParsed, executionContext));
+            expression = expression.replace(functionParse, await this.ExecuteFunctionContextSwitch(sector, item, null, null, functionParsed, executionContext));
         }
         return (expression);
     }
@@ -143,9 +146,9 @@ class DrapoFunctionHandler {
     }
 
     private async ResolveFunctionExpression(sector: string, contextItem: DrapoContextItem, executionContext: DrapoExecutionContext<any>, expression: string): Promise<string> {
-        //Replace inner function expressions first
+        //Replace inner function expressions first, also against the element's own context item
         const context: DrapoContext = contextItem != null ? contextItem.Context : new DrapoContext();
-        let resolved: string = await this.ReplaceFunctionExpressions(sector, context, expression, false);
+        let resolved: string = await this.ReplaceFunctionExpressions(sector, context, expression, false, contextItem);
         //Resolve mustaches against the element's own context item. The shared context cursor (context.Item)
         //is left pointing at the LAST iterated row after a render, so resolving through the context reads the
         //wrong row when the function runs from an event raised on any other row.

--- a/src/Test/WebDrapo.Test/ReleaseTest.cs
+++ b/src/Test/WebDrapo.Test/ReleaseTest.cs
@@ -6,6 +6,7 @@ using System.Text.RegularExpressions;
 using OpenQA.Selenium;
 using System.Text;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace WebDrapo.Test
 {
@@ -1401,9 +1402,83 @@ namespace WebDrapo.Test
             IWebElement active = Driver.SwitchTo().ActiveElement();
             string activeDId = active.GetDomAttribute("d-id");
             Assert.That(activeDId, Is.EqualTo("perc4"), "Focus should remain on the next field (May) after the model-change notify.");
-            // The calculated financial field must have been updated (proves the notify still happened).
+            // The calculated financial field must have been updated with the value of ITS OWN row
+            // (1000 * 0.1 = 100). A weaker not-zero assertion used to hide the expression resolving
+            // the percentage against the context cursor (the last rendered row) instead of the edited row.
             IWebElement aprilValue = Driver.FindElement(By.CssSelector("[d-id='val3']"));
-            Assert.That(aprilValue.Text.Trim(), Is.Not.EqualTo("0"), "The calculated field must update after the model change.");
+            Assert.That(aprilValue.Text.Trim(), Is.EqualTo("100"), "The calculated field must update with the edited row's own percentage after the model change.");
+        }
+        [TestCase]
+        public void ModelChangeSecondEditStaleTest()
+        {
+            // Regression: Cast (and Round/EncodeUrl) resolved context mustaches through the shared context
+            // cursor, which points at the LAST rendered row after a render. Editing any other row computed
+            // with the wrong row's percentage (blank -> 'total*' -> total), and re-editing the same field
+            // looked frozen because the wrong result never changed. Both edits below must compute with the
+            // edited row's own value.
+            string pageUrl = string.Format("{0}DrapoPages/{1}.html", VirtualDirectory, "Bug_ModelChangeSecondEditStale");
+            Driver.Navigate().GoToUrl(pageUrl);
+            IJavaScriptExecutor js = (IJavaScriptExecutor)Driver;
+            for (int i = 0; i < 20; i++)
+            {
+                bool loaded = (bool)js.ExecuteScript("return(drapo._isLoaded);");
+                if (loaded)
+                    break;
+                System.Threading.Thread.Sleep(100);
+            }
+            // First edit on the FIRST row (not the last, where the cursor bug was masked).
+            IWebElement jan = Driver.FindElements(By.CssSelector("input")).First(el => el.Displayed);
+            jan.Click();
+            jan.SendKeys("0.1");
+            jan.SendKeys(Keys.Tab);
+            System.Threading.Thread.Sleep(1000);
+            IWebElement janValue = Driver.FindElements(By.CssSelector("span.month-value")).First(el => el.Displayed);
+            Assert.That(janValue.Text.Trim(), Is.EqualTo("100"), "The first edit must compute with the edited row's own percentage (1000 * 0.1).");
+            // Second edit on the SAME field must recompute (the customer symptom was a frozen value).
+            jan = Driver.FindElements(By.CssSelector("input")).First(el => el.Displayed);
+            jan.Click();
+            jan.Clear();
+            jan.SendKeys("0.25");
+            jan.SendKeys(Keys.Tab);
+            System.Threading.Thread.Sleep(1000);
+            janValue = Driver.FindElements(By.CssSelector("span.month-value")).First(el => el.Displayed);
+            Assert.That(janValue.Text.Trim(), Is.EqualTo("250"), "A second edit of the same field must recompute with the new percentage (1000 * 0.25).");
+        }
+        [TestCase]
+        public void ModelChangeFocusNoDIdTest()
+        {
+            // Regression: the focus preservation across a d-for rebuild only worked for elements with a
+            // d-id. Inputs without d-id (the common case in real forms and the docs sample) lost focus to
+            // the body when d-if forced the full rebuild path. The structural fallback must restore focus
+            // to the recreated input at the same position.
+            string pageUrl = string.Format("{0}DrapoPages/{1}.html", VirtualDirectory, "Bug_ModelChangeFocusNoDId");
+            Driver.Navigate().GoToUrl(pageUrl);
+            IJavaScriptExecutor js = (IJavaScriptExecutor)Driver;
+            for (int i = 0; i < 20; i++)
+            {
+                bool loaded = (bool)js.ExecuteScript("return(drapo._isLoaded);");
+                if (loaded)
+                    break;
+                System.Threading.Thread.Sleep(100);
+            }
+            // Type a percentage into January and Tab to February. The blur updates the data and defers the
+            // notify; the d-if on the row forces the full-rebuild path that recreates the inputs.
+            IWebElement jan = Driver.FindElements(By.CssSelector("input.perc-input")).First(el => el.Displayed);
+            jan.Click();
+            jan.SendKeys("0.5");
+            jan.SendKeys(Keys.Tab);
+            System.Threading.Thread.Sleep(1000);
+            // Focus must be on February (the second visible input) instead of falling back to the body.
+            IWebElement active = Driver.SwitchTo().ActiveElement();
+            Assert.That(active.TagName.ToLower(), Is.EqualTo("input"), "Focus must not fall back to the body after the rebuild.");
+            var visibleInputs = Driver.FindElements(By.CssSelector("input.perc-input")).Where(el => el.Displayed).ToList();
+            Assert.That(active.Equals(visibleInputs[1]), Is.True, "Focus must be restored to the field being tabbed into (February).");
+            // The calculation still happened with the edited row's own percentage.
+            bool valueUpdated = false;
+            foreach (IWebElement span in Driver.FindElements(By.CssSelector("span")))
+                if (span.Displayed && span.Text.Trim() == "500")
+                    valueUpdated = true;
+            Assert.That(valueUpdated, Is.True, "The calculated field must update with the edited row's own percentage (1000 * 0.5).");
         }
         [TestCase]
         public void ModelChangeFocusFunctionTest()

--- a/src/Web/WebDrapo/wwwroot/DrapoPages/Bug_ModelChangeFocusNoDId.html
+++ b/src/Web/WebDrapo/wwwroot/DrapoPages/Bug_ModelChangeFocusNoDId.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="/drapo.js"></script>
+    <title>Bug - Model Change Focus Without d-id</title>
+</head>
+<body>
+    <span>Bug - Model Change Focus Without d-id</span>
+    <!-- Customer structure: d-if on the row (forces the full-rebuild render path) and inputs
+         WITHOUT d-id. Customer report: the calculation works but the field loses focus. -->
+    <div d-datakey="total" d-datatype="value" d-datavalue="1000"></div>
+    <div d-datakey="months" d-datatype="array"
+         d-datavalue="[{&quot;Month&quot;:&quot;Jan&quot;,&quot;Perc&quot;:&quot;&quot;,&quot;Value&quot;:&quot;0&quot;},{&quot;Month&quot;:&quot;Feb&quot;,&quot;Perc&quot;:&quot;&quot;,&quot;Value&quot;:&quot;0&quot;},{&quot;Month&quot;:&quot;Mar&quot;,&quot;Perc&quot;:&quot;&quot;,&quot;Value&quot;:&quot;0&quot;}]"></div>
+    <div>
+        <div d-for="month in months" d-if="{{total}}>0">
+            <span>{{month.Month}}: </span>
+            <input type="text"
+                   class="perc-input"
+                   d-model="{{month.Perc}}"
+                   d-model-event="blur"
+                   d-modelNotify="false"
+                   d-on-model-change="UpdateItemField({{month.Value}},Cast({{total}}*{{month.Perc}},number),false);Async(Notify(months),0)" />
+            <span>{{month.Value}}</span>
+            <br />
+        </div>
+    </div>
+</body>
+</html>

--- a/src/Web/WebDrapo/wwwroot/DrapoPages/Bug_ModelChangeSecondEditStale.html
+++ b/src/Web/WebDrapo/wwwroot/DrapoPages/Bug_ModelChangeSecondEditStale.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="/drapo.js"></script>
+    <title>Bug - Model Change Second Edit Stale</title>
+</head>
+<body>
+    <span>Bug - Model Change Second Edit Stale</span>
+    <!-- Exact structure of the docs Async sample 003: no d-id, no d-if.
+         Customer report: the FIRST edit updates the calculated value, but editing the SAME field
+         again does not update it anymore. -->
+    <div d-datakey="total" d-datatype="value" d-datavalue="1000"></div>
+    <div d-datakey="months" d-datatype="array"
+         d-datavalue="[{&quot;Month&quot;:&quot;Jan&quot;,&quot;Perc&quot;:&quot;&quot;,&quot;Value&quot;:&quot;0&quot;},{&quot;Month&quot;:&quot;Feb&quot;,&quot;Perc&quot;:&quot;&quot;,&quot;Value&quot;:&quot;0&quot;},{&quot;Month&quot;:&quot;Mar&quot;,&quot;Perc&quot;:&quot;&quot;,&quot;Value&quot;:&quot;0&quot;}]"></div>
+    <div>
+        <div d-for="month in months">
+            <span>{{month.Month}}: </span>
+            <input type="text"
+                   d-model="{{month.Perc}}"
+                   d-model-event="blur"
+                   d-modelNotify="false"
+                   d-on-model-change="UpdateItemField({{month.Value}},Cast({{total}}*{{month.Perc}},number),false);Async(Notify(months),0)" />
+            <span class="month-value">{{month.Value}}</span>
+            <br />
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
Closes #673. Follow-up to #672, reported from a real-world 12-month worksheet using the documented `UpdateItemField` + `Async(Notify(...),0)` pattern.

## Problem

1. **Calculation uses the wrong row (looks frozen on re-edit).** `Cast`/`Round`/`EncodeUrl` resolved their expression through the shared context cursor (`context.Item`), which is left pointing at the **last rendered row** after every render. From a `d-on-model-change` on any other row, `{{row.Field}}` read the last row (blank on the docs sample), so `Cast({{total}}*{{month.Perc}},number)` parsed `"1000*"` and stored `total` for every row except the last. Re-editing the same field recomputed the same wrong value, so it looked frozen. The #672 regression test only asserted `Not("0")`, which the wrong `1000` passed.

2. **Focus still lost when the input has no `d-id`.** The #672 focus preservation snapshots the focused element by `d-id` only. Plain inputs (docs sample, real forms) still lost focus to the body when `d-if` forced the full-rebuild path.

## Fix

- **`DrapoFunctionHandler`** — new `ResolveFunctionExpression` helper: replaces nested function expressions first (as the Barber did), then resolves each mustache with `Solver.ResolveItemDataPathObject` against the element''s **own context item** (parent-chain walk + storage-data-key fallback, so `{{total}}` keeps working). `Cast`, `Round` and `EncodeUrl` now use it.
- **`DrapoDocument`** — `GetFocusStateForElement` gains a structural fallback: when the focused element has no `d-id`, it records the element''s position among the focusable elements (`input, textarea, select`) of the rebuilt scope; `RestoreFocusState` focuses the recreated element at that position (caret preserved). `d-id` still wins when present.
- **`DrapoControlFlow`** — passes the rebuild scope into the snapshot so the position can be captured before the rebuild.

## Tests (DrapoPages + ReleaseTest)

- `ModelChangeSecondEditStaleTest` — two consecutive edits on the FIRST row compute with that row''s own percentage (100, then 250). Page is the exact docs Async sample (no `d-id`, no `d-if`).
- `ModelChangeFocusNoDIdTest` — customer shape (`d-if` row, no `d-id`): Tab keeps focus on the next input across the rebuild and the calc uses the edited row (500).
- `ModelChangeUpdateItemFieldFocusTest` — assertion strengthened from `Not("0")` to the exact per-row value (`100`) so cursor-row leaks cannot pass again.

## Verification

- `npx tslint --project tsconfig/production/` → pass · `dotnet build` → 0 errors
- The 5 focus/notify/timespan tests pass together (9 s). Full suite: 353/355 passed; the 2 failures (`ParameterFunctionMustacheInsideTest`, `ValidationEventInputTextSpaceTest`) are the documented parallel-load flakes — both pass in isolation, and neither page uses the changed code paths'' event flow.
- Reproduced and verified both customer symptoms end-to-end in the browser (Playwright) before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)