### PR TITLE
fix(677): file datakey error handling — decode Blob error bodies; no download without a body

### DIFF
--- a/src/Middleware/Drapo/ts/DrapoFunctionHandler.ts
+++ b/src/Middleware/Drapo/ts/DrapoFunctionHandler.ts
@@ -1589,6 +1589,9 @@ class DrapoFunctionHandler {
         const name: any = await this.Application.Solver.ResolveItemDataPathObject(sector, contextItem, namePath, true);
         const dataPath: string[] = this.Application.Solver.CreateDataPath(dataKeyFile, ['body']);
         const data: any = await this.Application.Solver.ResolveItemDataPathObject(sector, contextItem, dataPath, true);
+        //A file item without a body (e.g. the request failed) has nothing to download
+        if ((data == null) || (data === ''))
+            return ('');
         const contentTypePath: string[] = this.Application.Solver.CreateDataPath(dataKeyFile, ['contenttype']);
         const contentType: any = await this.Application.Solver.ResolveItemDataPathObject(sector, contextItem, contentTypePath, true);
         this.DownloadData(name, data, contentType);

--- a/src/Middleware/Drapo/ts/DrapoServer.ts
+++ b/src/Middleware/Drapo/ts/DrapoServer.ts
@@ -204,6 +204,9 @@ class DrapoServer {
         const urlResolvedTimestamp: string = await this.AppendUrlQueryStringTimestamp(urlResolved);
         const request: DrapoServerRequest = new DrapoServerRequest(verb, urlResolvedTimestamp, requestHeaders, data, true, true);
         const response: DrapoServerResponse = await this.Request(request);
+        //Binary request: error bodies arrive as Blob; convert to text so they can be deserialized
+        if ((response.Status !== 200) && (response.Body != null) && (response.Body instanceof Blob))
+            response.Body = await this.ConvertBlobToText(response.Body);
         //Redirect
         if ((200 <= response.Status) && (response.Status < 400)) {
             const location: string = this.GetHeaderValue(response.Headers, 'Location');
@@ -301,6 +304,15 @@ class DrapoServer {
             }
         }
         return (object);
+    }
+
+    private ConvertBlobToText(body: Blob): Promise<string> {
+        return (new Promise<string>((resolve) => {
+            const reader: FileReader = new FileReader();
+            reader.onload = () => { resolve(reader.result as string); };
+            reader.onerror = () => { resolve(''); };
+            reader.readAsText(body);
+        }));
     }
 
     private ConvertFileBody(body: string): string {


### PR DESCRIPTION
Fixes #677.

## Problem
For a `d-dataType="file"` datakey (binary XHR, `responseType='blob'`):
1. A 400/500 response body arrives as a `Blob`; `GetFile` passed it straight to `Serializer.Deserialize`/`IsJson`, which silently fail on a Blob — so `StorageBadRequest`/`StorageErrors` held a raw Blob and the application's OnBadRequest window rendered **empty** (mustaches like `{{badRequest.Text}}` resolve to nothing).
2. `DownloadData(dataKey)` after a failed fetch still ran: with no `body`/`filename` in the file item, the browser saved a GUID-named, 0-byte `.txt` — the user gets a garbage download instead of an error.

Observed in production use: a "download PowerPoint" ribbon action against a failing endpoint handed the user an empty `<guid>.txt` plus an empty error window.

## Fix
- `DrapoServer.GetFile`: when the response status is not 200 and the body is a `Blob`, convert it to text (FileReader, ES5-safe) before the status branches — the existing 400/500 handling then deserializes and stores the real message.
- `DrapoFunctionHandler.ExecuteFunctionDownloadData`: return without downloading when the resolved file `body` is null/empty. A legitimately empty file (200 with a zero-length Blob) still downloads — the guard only skips a missing body, not an empty Blob.

## Verification
- Consumer app E2E (PowerPlanning canvas PowerPoint export, patched DLL):
  - Endpoint failing → **no download**, BadRequest window shows the server's `Text` message (was: empty window + GUID `.txt`).
  - Endpoint healthy → valid `.pptx` downloads unchanged (`PK` magic verified).
- `dotnet test --filter DataFileTest|DataFileUnicodeTest|FunctionDownloadDataBinaryTest` → 3/3 passed against the local WebDrapo host.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)