### PR TITLE
docs: forbid AI agents from approving or merging pull requests

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,6 +9,8 @@
 
 **No exceptions - these requirements are mandatory for all code changes.**
 
+4. 🚫 **NEVER approve or merge a pull request** - no `gh pr merge`, no `--admin` override, no review approvals. Open the PR, report CI status, and stop: a human maintainer merges. Merging `master` auto-publishes the `Drapo` package to nuget.org, so the merge is a human-only release decision.
+
 ---
 
 ## About Drapo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,15 @@ Core middleware (NuGet `Drapo`) plus a TypeScript-compiled client runtime (`drap
 These are non-negotiable. A Release build runs TSLint and fails if it does not pass.
 Resolve errors in order: TSLint → C# compilation → missing dependencies.
 
+## 🚫 PR discipline — humans merge, never the agent
+
+**NEVER approve or merge a pull request in this repository — no `gh pr merge`, no
+`--admin` override, no review approvals.** Open the PR, link its issue, report the CI
+status, and STOP: a human maintainer decides the merge. Merging to `master`
+automatically publishes a new `Drapo` package to nuget.org that every consumer picks
+up, so the merge is a release decision and it is human-only. This applies even when CI
+is green, the change is urgent, or a downstream repo is waiting on the release.
+
 ## Project documentation
 
 Detailed project knowledge lives in [`doc/`](doc/README.md) — read the relevant doc


### PR DESCRIPTION
Fixes #679.

Adds an explicit rule to both agent instruction files (`CLAUDE.md` and `.github/copilot-instructions.md`):

> **NEVER approve or merge a pull request in this repository** — no `gh pr merge`, no `--admin` override, no review approvals. Open the PR, link its issue, report the CI status, and STOP: a human maintainer decides the merge. Merging `master` auto-publishes the `Drapo` package to nuget.org, so the merge is a release decision and it is human-only — even when CI is green, the change is urgent, or a downstream repo is waiting on the release.

Context: PR #678 was admin-merged by an AI agent; the repo owner has ruled that drapo merges are human-only. Docs-only change — no code, no tests affected.

This PR itself is left for a human maintainer to review and merge.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)