### PR TITLE
build(666): migrate the TypeScript toolchain to TypeScript 7.0

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,7 +4,7 @@
 
 **Every code change MUST:**
 1. ✅ **Compile successfully** - `cd src && dotnet build Drapo.sln`  
-2. ✅ **Pass TSLint without errors** - `cd src/Middleware/Drapo && npx tslint --project tsconfig/production/`
+2. ✅ **Pass TSLint without errors** - `cd src/Middleware/Drapo && npm run lint`
 3. ✅ **Include unit tests** when adding new functionality (following existing patterns)
 
 **No exceptions - these requirements are mandatory for all code changes.**
@@ -114,7 +114,7 @@ The `ValidatePage()` method:
 cd src/Middleware/Drapo && npm install
 
 # MANDATORY: Check TypeScript compilation and linting 
-cd src/Middleware/Drapo && npx tslint --project tsconfig/production/
+cd src/Middleware/Drapo && npm run lint
 
 # Verify C# test project builds (independent validation)
 cd src && dotnet build Test/WebDrapo.Test/WebDrapo.Test.csproj
@@ -130,7 +130,7 @@ cd src && dotnet build Test/WebDrapo.Test/WebDrapo.Test.csproj
 - **Project-level builds**: Individual project builds must succeed even if full solution has integration complexities
 
 ### Error Resolution Process
-1. **Check TypeScript linting first**: Run `npx tslint --project tsconfig/production/` - this MUST pass
+1. **Check TypeScript linting first**: Run `npm run lint` - this MUST pass
 2. **Check C# compilation**: Build individual projects to isolate issues
 3. **Install missing dependencies**: Use `npm install` for TypeScript dependencies  
 4. **Address linting errors**: Fix any TypeScript code style or quality issues before proceeding
@@ -202,11 +202,11 @@ Cover these areas when creating tests:
 
 **Before making any code changes:**
 1. Install dependencies if needed: `cd src/Middleware/Drapo && npm install`
-2. Verify TSLint passes: `cd src/Middleware/Drapo && npx tslint --project tsconfig/production/`
+2. Verify TSLint passes: `cd src/Middleware/Drapo && npm run lint`
 3. Check baseline build status: `cd src && dotnet build Test/WebDrapo.Test/WebDrapo.Test.csproj`
 
 **After making any code changes:**
-1. **ALWAYS run TSLint**: `cd src/Middleware/Drapo && npx tslint --project tsconfig/production/` (MANDATORY)
+1. **ALWAYS run TSLint**: `cd src/Middleware/Drapo && npm run lint` (MANDATORY)
 2. **Verify test project builds**: `cd src && dotnet build Test/WebDrapo.Test/WebDrapo.Test.csproj`
 3. **Fix any errors** before proceeding with further changes
 4. **Run unit tests** if changes affect existing functionality

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -12,7 +12,7 @@ hand-written script. New behavior must compose with the existing attribute model
 No change is complete until it compiles and lints cleanly:
 - C# / .NET solution builds: `cd src && dotnet build Drapo.sln`
 - TypeScript passes TSLint with zero errors:
-  `cd src/Middleware/Drapo && npx tslint --project tsconfig/production/`
+  `cd src/Middleware/Drapo && npm run lint`
 
 Linting and compilation are gates, not suggestions. Broken builds are never merged.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Core middleware (NuGet `Drapo`) plus a TypeScript-compiled client runtime (`drap
 **Every code change MUST:**
 
 1. **Compile** — `cd src && dotnet build Drapo.sln`
-2. **Pass TSLint with zero errors** — `cd src/Middleware/Drapo && npx tslint --project tsconfig/production/`
+2. **Pass TSLint with zero errors** — `cd src/Middleware/Drapo && npm run lint`
 3. **Include or update tests** — follow the DrapoPages testing workflow in [doc/development.md](doc/development.md)
 4. **Keep the full test suite green** — a PR is only approved when **all** tests pass.
    Run them locally against a running WebDrapo (`dotnet test` with

--- a/COPILOT.md
+++ b/COPILOT.md
@@ -12,7 +12,7 @@ Detailed project documentation is centralized in **[doc/](doc/README.md)**:
 ## Key reminders
 
 - 🚨 **Validate builds and linting before changes** — TSLint must pass:
-  `cd src/Middleware/Drapo && npx tslint --project tsconfig/production/`
+  `cd src/Middleware/Drapo && npm run lint`
 - **Create or update unit tests** for any behavior change (DrapoPages workflow in
   [doc/development.md](doc/development.md)).
 - **Use Drapo's declarative `d-*` attributes** instead of JavaScript.

--- a/README.md
+++ b/README.md
@@ -465,7 +465,7 @@ We welcome contributions to Drapo! Here's how to get started:
 1. **Create a Feature Branch**: `git checkout -b feature/your-feature-name`
 2. **Make Changes**: Implement your feature or bug fix
 3. **Add Tests**: Cover changes with DrapoPages tests (see the [Development Guide](doc/development.md#testing-workflow))
-4. **Build and Lint**: `dotnet build Drapo.sln` and `npx tslint --project tsconfig/production/` must both be clean
+4. **Build and Lint**: `dotnet build Drapo.sln` and `npm run lint` must both be clean
 5. **Run the full suite**: every test must pass — **a PR is only approved when all tests pass**
 6. **Submit Pull Request**: Create a PR with a clear description
 
@@ -502,7 +502,8 @@ When reporting bugs or requesting features:
   - .NET 8.0
   - .NET 6.0  
   - .NET Core 3.1
-- **Browser Support**: Modern browsers (Chrome, Firefox, Safari, Edge)
+- **Browser Support**: Modern browsers (Chrome, Firefox, Safari, Edge) — the runtime is
+  compiled to ES2015
 
 ## 📄 License
 

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -20,8 +20,8 @@ JavaScript. It ships as two cooperating parts:
 
 | Area | Technology |
 |------|------------|
-| Client runtime | TypeScript 5.0.4 → `drapo.js` (compiled via `tsc`) |
-| Client lint | TSLint 6.1.3 (`tslint.json`) |
+| Client runtime | TypeScript 7.0.2 (native compiler) → `drapo.js`; production target ES2015, development target ES2022 |
+| Client lint | TSLint 6.1.3 (`tslint.json`), running on the `@typescript/typescript6` compiler API via `scripts/tslint.cjs` |
 | Real-time | `@microsoft/signalr` 3.1.17 (WebSocket pipes) |
 | Minification | `uglify-js` |
 | Server | ASP.NET Core middleware in C# |
@@ -41,6 +41,7 @@ src/
 │   ├── tsconfig/development/       # Dev tsconfig (used for Debug builds)
 │   ├── tsconfig/production/        # Prod tsconfig (used for TSLint + Release builds)
 │   ├── tslint.json                 # TSLint rules
+│   ├── scripts/                    # create-lib.mjs (bundle drapo.js) and tslint.cjs (TSLint on TypeScript 7)
 │   ├── components/                 # Built-in components (e.g. debugger)
 │   ├── lib/<tfm>/                  # Per-framework build artifacts
 │   ├── *.cs                        # ASP.NET Core middleware + server-side types
@@ -101,16 +102,30 @@ serves the framework and its resources:
 
 ## Build pipeline
 
-The TypeScript build is wired into the C# project (`Drapo.csproj`) via
-`Microsoft.TypeScript.MSBuild`, so building the package also lints and compiles the
-runtime:
+The TypeScript build is wired into the C# project (`Drapo.csproj`), so building the
+package also lints and compiles the runtime. The commands live in
+`src/Middleware/Drapo/package.json` and run the TypeScript 7 native compiler from
+`node_modules`:
 
-- **Release** builds run `npx tslint --project tsconfig/production/` and then
-  `npx tsc -p tsconfig/production/tsconfig.json`.
-- **Debug** builds compile with `tsconfig/development/tsconfig.json`.
-- For multi-target builds, TypeScript is compiled **once** in the outer (cross-target)
-  build before the per-framework inner builds run in parallel, avoiding races on the
-  shared `js/` output. Inner builds have TypeScript compilation blocked.
+- **Release** builds run `npm run lint` (TSLint) and then `npm run compile`
+  (`tsconfig/production/tsconfig.json`, target ES2015).
+- **Debug** builds run `npm run compile:dev` (`tsconfig/development/tsconfig.json`,
+  target ES2022, source maps).
+- TypeScript is compiled **once** in the outer (cross-target) build before the
+  per-framework inner builds run in parallel, avoiding races on the shared `js/`
+  output. Each inner build then bundles `js/` with the runtime dependencies into
+  `lib/<tfm>/drapo.js`, minifies it with `uglify-js`, and embeds both files.
+- The `Microsoft.TypeScript.MSBuild` package (7.x) is referenced for the Visual Studio
+  integration only; its own compilation is blocked (`TypeScriptCompileBlocked`) so the
+  runtime is never compiled twice. `WebDrapo` does use that package to compile its
+  demo components (`wwwroot/components/**/*.ts`) with the project's `tsconfig.json`.
+
+**TypeScript 7 notes.** The native compiler has no JavaScript API and no ES5 target.
+TSLint needs that API, so `scripts/tslint.cjs` redirects its `require('typescript')`
+to Microsoft's `@typescript/typescript6` compatibility package while `tsc` itself is
+TypeScript 7. The production output moved from ES5 to ES2015 (the lowest target
+TypeScript 7 supports); every browser that supports ES2015 classes also has native
+`Promise`, and the bundled `es6-promise` polyfill remains for backward compatibility.
 
 This is why **TSLint passing is a hard gate**: a Release build will fail if it doesn't.
 See [development.md](development.md) for the exact commands.

--- a/doc/development.md
+++ b/doc/development.md
@@ -9,7 +9,7 @@ For the system design and code layout, see [architecture.md](architecture.md).
 
 1. **Compiles** — `cd src && dotnet build Drapo.sln`
 2. **Passes TSLint with zero errors** —
-   `cd src/Middleware/Drapo && npx tslint --project tsconfig/production/`
+   `cd src/Middleware/Drapo && npm run lint`
 3. **Has tests** — new functionality includes tests; modified functionality updates
    the affected tests (see [Testing workflow](#testing-workflow)).
 4. **Passes the full test suite** — every test must be green. A PR can only be approved
@@ -20,7 +20,8 @@ These are non-negotiable. A Release build runs TSLint and will fail if it does n
 ## Prerequisites
 
 - .NET SDK `10.0.100` (pinned in `global.json`; `rollForward: latestFeature`)
-- Node.js + npm (for the TypeScript toolchain)
+- Node.js 16.20+ + npm (TypeScript 7 ships as a native binary for Windows, Linux, and
+  macOS on x64/arm64)
 
 ## Build & lint commands
 
@@ -29,10 +30,12 @@ These are non-negotiable. A Release build runs TSLint and will fail if it does n
 cd src/Middleware/Drapo && npm install
 
 # MANDATORY: TypeScript lint — must pass with zero errors
-cd src/Middleware/Drapo && npx tslint --project tsconfig/production/
+# (runs TSLint through scripts/tslint.cjs, which gives it the TypeScript 6 compiler API)
+cd src/Middleware/Drapo && npm run lint
 
 # Compile the TypeScript runtime directly (optional; the build also does this)
-cd src/Middleware/Drapo && npx tsc -p tsconfig/production/tsconfig.json
+cd src/Middleware/Drapo && npm run compile       # production tsconfig (ES2015, no source maps)
+cd src/Middleware/Drapo && npm run compile:dev   # development tsconfig (ES2022, source maps)
 
 # Build the full solution
 cd src && dotnet build Drapo.sln
@@ -167,7 +170,7 @@ Additional guidance:
 
 Before opening a PR:
 
-- [ ] `npx tslint --project tsconfig/production/` passes with zero errors
+- [ ] `npm run lint` passes with zero errors
 - [ ] `dotnet build Drapo.sln` succeeds
 - [ ] New/changed behavior has DrapoPages tests, registered in `ReleaseTest.cs`
 - [ ] **The full test suite passes** (run against a local WebDrapo — see

--- a/src/Extension/README.md
+++ b/src/Extension/README.md
@@ -183,7 +183,7 @@ Use the Drapo client mock to validate `window.drapo.Bridge` against the unpacked
 ```bash
 cd src/Middleware/Drapo
 npm install
-npx tsc -p tsconfig/development/tsconfig.json
+npm run compile:dev
 
 cd ../../Extension
 npm install

--- a/src/Extension/package.json
+++ b/src/Extension/package.json
@@ -14,6 +14,6 @@
     "mock": "node mock/drapo-client-server.mjs"
   },
   "devDependencies": {
-    "typescript": "5.4.5"
+    "typescript": "7.0.2"
   }
 }

--- a/src/Extension/tsconfig.json
+++ b/src/Extension/tsconfig.json
@@ -1,19 +1,20 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "alwaysStrict": true,
     "declaration": false,
     "lib": ["dom", "es2020"],
-    "module": "none",
     "noEmitOnError": true,
     "noImplicitAny": true,
     "noImplicitThis": true,
     "outDir": "dist",
     "removeComments": true,
+    "rootDir": "src",
     "sourceMap": false,
+    "strict": false,
     "strictFunctionTypes": true,
     "strictNullChecks": false,
-    "target": "es2020"
+    "target": "es2020",
+    "types": []
   },
   "include": ["src/**/*.ts"]
 }

--- a/src/Middleware/Drapo/Drapo.csproj
+++ b/src/Middleware/Drapo/Drapo.csproj
@@ -9,58 +9,43 @@
 		<AssemblyName>Sysphera.Middleware.Drapo</AssemblyName>
 		<RootNamespace>Sysphera.Middleware.Drapo</RootNamespace>
 	</PropertyGroup>
-	<Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.Default.props" Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.Default.props')" />
+	<!-- The TypeScript runtime is linted and compiled explicitly by the CompileTypeScriptRuntime target below (npm scripts in
+	     package.json, using the TypeScript 7 native compiler from node_modules). The Microsoft.TypeScript.MSBuild package is
+	     kept for the Visual Studio integration (TypeScript project properties, file nesting), but its own compilation is
+	     blocked so that the runtime is never compiled twice or by a different compiler. -->
 	<PropertyGroup>
-		<TypeScriptToolsVersion>Latest</TypeScriptToolsVersion>
-		<TypeScriptCompileBlocked>false</TypeScriptCompileBlocked>
+		<TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.TypeScript.MSBuild" Version="5.4.5">
+		<PackageReference Include="Microsoft.TypeScript.MSBuild" Version="7.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<Content Include="tsconfig/development/tsconfig.json" Condition="'$(Configuration)' == 'Debug'" />
-		<Content Include="tsconfig/production/tsconfig.json" Condition="'$(Configuration)' == 'Release'" />
 	</ItemGroup>
-	<!-- Workaround for the bugged target TypeScriptDeleteOutputFromOtherConfigs from Microsoft.TypeScript.targets: https://github.com/microsoft/TypeScript/issues/50428
-	     Running in the outer build (BeforeTargets="DispatchToInnerBuilds") deletes all .out files once before inner builds start in parallel,
-	     so each inner build's TypeScriptDeleteOutputFromOtherConfigs finds nothing to delete.
-	     IsInnerBuild='true' is excluded to prevent parallel inner builds from conflicting on the same .out files. -->
-	<Target Name="FixDeniedAccessOnDelete" BeforeTargets="TypeScriptDeleteOutputFromOtherConfigs;DispatchToInnerBuilds" Condition="'$(IsInnerBuild)' != 'true' AND '$(BuildingProject)' != 'false' AND '$(DesignTimeBuild)' != 'true'">
-		<ItemGroup>
-			<TSOutputLogsToDelete Include="$(BaseIntermediateOutputPath)\**\Tsc*.out"/>
-		</ItemGroup>
-		<Delete Files="@(TSOutputLogsToDelete)" Condition="'@(TSOutputLogsToDelete)' != '' " />
-	</Target>
 	<Target Name="CleanLibFiles" BeforeTargets="Clean" Condition="'$(DesignTimeBuild)' != 'true'">
 		<ItemGroup>
 			<FilesToDelete Include="lib\$(TargetFramework)\**\*" />
 		</ItemGroup>
 		<Delete Files="@(FilesToDelete)" />
 	</Target>
-	<!-- Block TypeScript in inner builds of multi-target builds; compilation is handled once in the outer build by CompileTypeScriptOnce.
-	     IsInnerBuild is set late by NuGet.Build.Tasks.Pack.targets (after PropertyGroup evaluation), so we must set
-	     TypeScriptCompileBlocked inside a target (dynamic PropertyGroup) where IsInnerBuild is correctly available. -->
-	<Target Name="BlockTypeScriptInInnerBuilds" BeforeTargets="CompileTypeScriptWithTSConfig">
-		<PropertyGroup Condition="'$(IsInnerBuild)' == 'true'">
-			<TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
-		</PropertyGroup>
+	<!-- Lint and compile the TypeScript runtime exactly once per build, in the outer (cross-targeting) build, before the
+	     per-framework inner builds are dispatched in parallel. This prevents EBUSY race conditions caused by multiple inner
+	     builds writing to the shared js/ directory simultaneously.
+	     Note: BuildingProject is only set to 'true' in inner builds (by BuildOnlySettings target), not in the outer
+	     cross-targeting build, so it must NOT be used as a condition here. IsCrossTargetingBuild=true is the outer-build guard.
+	     Single-framework builds ("dotnet build -f net10.0") are inner builds from the SDK's point of view and reuse the js/
+	     output of the last full build, as before.
+	     Release builds lint with TSLint (a hard gate) and compile with the production tsconfig; Debug builds compile with the
+	     development tsconfig. See the scripts in package.json for the underlying commands. -->
+	<Target Name="CompileTypeScriptRuntime" BeforeTargets="DispatchToInnerBuilds" Condition="'$(IsCrossTargetingBuild)' == 'true' AND '$(DesignTimeBuild)' != 'true'">
+		<Exec Command="npm run lint" Condition="'$(Configuration)' == 'Release'" />
+		<Exec Command="npm run compile" Condition="'$(Configuration)' == 'Release'" />
+		<Exec Command="npm run compile:dev" Condition="'$(Configuration)' != 'Release'" />
 	</Target>
-	<!-- Run TSLint and TypeScript once in the outer build before inner builds are dispatched in parallel.
-	     This prevents EBUSY race conditions caused by multiple inner builds writing to the shared js/ directory simultaneously.
-	     Note: BuildingProject is only set to 'true' in inner builds (by BuildOnlySettings target), not in the outer cross-targeting build,
-	     so we must NOT use BuildingProject=true as a condition here. IsCrossTargetingBuild=true is the correct outer-build guard. -->
-	<Target Name="CompileTypeScriptOnce" BeforeTargets="DispatchToInnerBuilds" Condition="'$(IsCrossTargetingBuild)' == 'true' AND '$(DesignTimeBuild)' != 'true'">
-		<Exec Command="npx tslint --project tsconfig/production/" Condition="'$(Configuration)' == 'Release'" />
-		<Exec Command="npx tslint --project tsconfig/production/" Condition="'$(Configuration)' == 'Release'" />
-		<Exec Command="npx tsc -p tsconfig/production/tsconfig.json" Condition="'$(Configuration)' == 'Release'" />
-		<Exec Command="npx tsc -p tsconfig/development/tsconfig.json" Condition="'$(Configuration)' != 'Release'" />
-	</Target>
-	<!-- For single-target builds (not inner builds), TSLint still runs via the standard BeforeTargets mechanism -->
-	<Target Name="TSLint" BeforeTargets="CompileTypeScriptWithTSConfig" Condition="$(TargetFrameworks.StartsWith($(TargetFramework))) AND $(Configuration) == 'Release' AND '$(BuildingProject)' == 'true' AND '$(DesignTimeBuild)' != 'true' AND '$(IsInnerBuild)' != 'true'">
-		<Exec Command="npx tslint --project tsconfig/production/" />
-	</Target>
-	<Target Name="CreateLibFiles" AfterTargets="CompileTypeScriptWithTSConfig" Condition="'$(BuildingProject)' == 'true' AND '$(DesignTimeBuild)' != 'true'">
+	<!-- Bundle the compiled runtime (js/) with its dependencies into lib/<tfm>/ and embed it. This must run before
+	     _GenerateCompileInputs collects the EmbeddedResource items for the compiler; PrepareResources is the last public
+	     step before that. -->
+	<Target Name="CreateLibFiles" AfterTargets="PrepareResources" Condition="'$(BuildingProject)' == 'true' AND '$(DesignTimeBuild)' != 'true'">
 		<Exec Command="node scripts/create-lib.mjs $(TargetFramework)" />
 		<Exec Command="npx uglify-js lib/$(TargetFramework)/drapo.js -o lib/$(TargetFramework)/drapo.min.js" />
 		<WriteLinesToFile File="lib\$(TargetFramework)\drapo.min.js" Lines="%0a//# sourceMappingURL=drapo.js.map" Overwrite="false" />
@@ -68,7 +53,7 @@
 			<EmbeddedResource Include="lib\$(TargetFramework)\*.js" WithCulture="false" Type="Non-Resx" />
 		</ItemGroup>
 	</Target>
-	<Target Name="CreateDebugLibFiles" AfterTargets="CompileTypeScriptWithTSConfig" Condition="'$(BuildingProject)' == 'true' AND '$(DesignTimeBuild)' != 'true' AND '$(Configuration)' == 'Debug'">
+	<Target Name="CreateDebugLibFiles" AfterTargets="CreateLibFiles" Condition="'$(BuildingProject)' == 'true' AND '$(DesignTimeBuild)' != 'true' AND '$(Configuration)' == 'Debug'">
 		<ItemGroup>
 			<LibFiles Include="js\*.map" />
 		</ItemGroup>
@@ -88,5 +73,4 @@
 		<PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
 		<PackageReference Include="StackExchange.Redis" Version="2.2.50" />
 	</ItemGroup>
-	<Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.targets" Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.targets')" />
 </Project>

--- a/src/Middleware/Drapo/package.json
+++ b/src/Middleware/Drapo/package.json
@@ -2,11 +2,17 @@
   "version": "1.0.0",
   "name": "asp.net",
   "private": true,
+  "scripts": {
+    "lint": "node scripts/tslint.cjs --project tsconfig/production/",
+    "compile": "tsc -p tsconfig/production/tsconfig.json",
+    "compile:dev": "tsc -p tsconfig/development/tsconfig.json"
+  },
   "devDependencies": {
-    "typescript": "5.0.4",
-    "tslint": "6.1.3",
-    "es6-promise": "4.2.4",
     "@microsoft/signalr": "3.1.17",
+    "@typescript/typescript6": "6.0.2",
+    "es6-promise": "4.2.4",
+    "tslint": "6.1.3",
+    "typescript": "7.0.2",
     "uglify-js": "^3.19.3"
   }
 }

--- a/src/Middleware/Drapo/scripts/tslint.cjs
+++ b/src/Middleware/Drapo/scripts/tslint.cjs
@@ -1,0 +1,23 @@
+// TSLint entry point for TypeScript 7.
+//
+// TypeScript 7 (the native compiler) no longer ships the JavaScript compiler API that
+// TSLint depends on, so `require('typescript')` from inside TSLint (and its `tsutils`
+// dependency) would resolve to an API-less package and crash. Microsoft publishes the
+// last JavaScript-based compiler as `@typescript/typescript6` exactly for tools in this
+// situation. This script redirects every `require('typescript')` made by TSLint to that
+// package and then runs the regular TSLint CLI with the original arguments.
+//
+// Usage (from src/Middleware/Drapo): node scripts/tslint.cjs --project tsconfig/production/
+'use strict';
+
+const Module = require('node:module');
+
+const typescript6 = require.resolve('@typescript/typescript6');
+const resolveFilename = Module._resolveFilename;
+Module._resolveFilename = function (request, ...rest) {
+  if (request === 'typescript')
+    return typescript6;
+  return resolveFilename.call(this, request, ...rest);
+};
+
+require('tslint/lib/tslintCli');

--- a/src/Middleware/Drapo/tsconfig/development/tsconfig.json
+++ b/src/Middleware/Drapo/tsconfig/development/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "alwaysStrict": true,
+    "strict": false,
     "noImplicitAny": true,
     "noImplicitThis": true,
     "strictFunctionTypes": true,
@@ -10,8 +10,10 @@
     "removeComments": false,
     "sourceMap": true,
     "target": "es2022",
+    "rootDir": "../../ts/",
     "outDir": "../../js/",
     "declaration": true,
+    "types": [],
     "lib": [
       "dom",
       "es2022"

--- a/src/Middleware/Drapo/tsconfig/production/tsconfig.json
+++ b/src/Middleware/Drapo/tsconfig/production/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "alwaysStrict": true,
+    "strict": false,
     "noImplicitAny": true,
     "noImplicitThis": true,
     "strictFunctionTypes": true,
@@ -9,14 +9,14 @@
     "noEmitOnError": true,
     "removeComments": true,
     "sourceMap": false,
-    "target": "es5",
+    "target": "es2015",
+    "rootDir": "../../ts/",
     "outDir": "../../js/",
     "declaration": true,
+    "types": [],
     "lib": [
       "dom",
-      "es5",
-      "es2015.promise",
-      "es6"
+      "es2015"
     ]
   },
   "exclude": [

--- a/src/Web/WebDrapo/WebDrapo.csproj
+++ b/src/Web/WebDrapo/WebDrapo.csproj
@@ -5,7 +5,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.0" />
-		<PackageReference Include="Microsoft.TypeScript.MSBuild" Version="5.4.5">
+		<PackageReference Include="Microsoft.TypeScript.MSBuild" Version="7.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
@@ -13,17 +13,23 @@
 	<ItemGroup>
 		<ProjectReference Include="..\..\Middleware\Drapo\Drapo.csproj" />
 	</ItemGroup>
+	<!-- The Microsoft.TypeScript.MSBuild 7.x package appends its TypeScript* properties to the tsc command line, where they
+	     would override tsconfig.json. Clear/disable them so tsconfig.json stays the single source of truth for the components. -->
+	<PropertyGroup>
+		<TypeScriptTarget></TypeScriptTarget>
+		<TypeScriptSourceMap>false</TypeScriptSourceMap>
+	</PropertyGroup>
 	<Target Name="CopyNodeModulesFiles" BeforeTargets="PrepareResources">
 		<Copy SourceFiles="..\..\Middleware\Drapo\lib\$(TargetFramework)\index.d.ts" DestinationFolder="node_modules\@types\drapo\" />
 	</Target>
-	<!-- TypeScript's TypeScriptDeleteCompilerOutput reads a .out log to know which emitted files to delete during
+	<!-- TypeScript's CleanTypeScriptOutputs reads the tsc-emitted.txt log to know which emitted files to delete during
 	     Clean. If those .js files (e.g. autoclick.js) are in wwwroot/ and get discovered as static web assets at
 	     project-load time, DefineStaticWebAssets (AssignTargetPaths) validates them BEFORE TypeScript can recompile.
-	     Fix: delete the .out log before TypeScriptDeleteCompilerOutput reads it so TypeScript Clean is a no-op.
-	     TypeScript recompiles on the next Build and writes a fresh .out log anyway. -->
-	<Target Name="PreserveTypeScriptOutputsFromClean" BeforeTargets="TypeScriptDeleteCompilerOutput" Condition="'$(DesignTimeBuild)' != 'true'">
+	     Fix: delete the log before CleanTypeScriptOutputs reads it so TypeScript Clean is a no-op.
+	     TypeScript recompiles on the next Build and writes a fresh log anyway. -->
+	<Target Name="PreserveTypeScriptOutputsFromClean" BeforeTargets="CleanTypeScriptOutputs" Condition="'$(DesignTimeBuild)' != 'true'">
 		<ItemGroup>
-			<TSOutFilesToPreserve Include="$(TSCompilerOutputLogDirectory)Tsc*.out" />
+			<TSOutFilesToPreserve Include="$(IntermediateOutputPath)tsc-emitted.txt" />
 		</ItemGroup>
 		<Delete Files="@(TSOutFilesToPreserve)" Condition="'@(TSOutFilesToPreserve)' != ''" />
 	</Target>

--- a/src/Web/WebDrapo/package.json
+++ b/src/Web/WebDrapo/package.json
@@ -3,9 +3,8 @@
   "name": "asp.net",
   "private": true,
   "devDependencies": {
-    "typescript": "5.0.4",
+    "typescript": "7.0.2",
     "natives": "1.1.6",
-    "es6-promise": "4.2.4",
-    "tslint": "6.1.3"
+    "es6-promise": "4.2.4"
   }
 }

--- a/src/Web/WebDrapo/tsconfig.json
+++ b/src/Web/WebDrapo/tsconfig.json
@@ -1,17 +1,19 @@
 {
   "compileOnSave": true,
   "compilerOptions": {
+    "strict": false,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "removeComments": true,
     "sourceMap": false,
-    "target": "es5",
+    "target": "es2015",
     "declaration": true,
+    "types": [
+      "drapo"
+    ],
     "lib": [
       "dom",
-      "es5",
-      "es2015.promise",
-      "es6"
+      "es2015"
     ]
   },
   "include": [


### PR DESCRIPTION
Closes #666

## Summary

Migrates every TypeScript project in the repository to **TypeScript 7.0.2** (the native compiler), keeping the runtime behaviour, the TSLint rule set, the supported browsers and all quality gates unchanged.

The TypeScript 7.0 announcement lists three things that matter for this repo: the ES5 target is gone (ES2015 is the minimum), `rootDir` and `types` have new defaults, and the package ships **no JavaScript compiler API**, which TSLint depends on. Everything below follows from those three.

## What changed

### `src/Middleware/Drapo` (the runtime)
- `typescript` 5.0.4 → **7.0.2**. Compile time for the 84 runtime files went from ~4.6 s to ~2.2 s (production tsconfig, this machine).
- **TSLint kept as-is** (6.1.3, same `tslint.json`). Added Microsoft's `@typescript/typescript6` (the last JS-based compiler, published exactly for tools in this situation) plus `scripts/tslint.cjs`, a 20-line entry point that redirects TSLint's `require('typescript')` to it. `tsc` itself is TypeScript 7.
- `package.json` scripts: `npm run lint`, `npm run compile`, `npm run compile:dev`. Docs and the csproj use these instead of the raw `npx` commands.
- `tsconfig/production`: `target` **es5 → es2015** (lowest target TS 7 supports), `lib: [dom, es2015]`. Both tsconfigs get explicit `rootDir`, `types: []` and `strict: false` so the new TS 6/7 defaults do not change the emitted layout or the checked semantics (`noImplicitAny`, `noImplicitThis`, `strictFunctionTypes`, `strictNullChecks: false` are exactly what was enforced before).
- `Drapo.csproj`: `Microsoft.TypeScript.MSBuild` 5.4.5 → **7.0.1**. The 7.x package is a rewrite (`RunTscCompile`/`CleanTypeScriptOutputs` instead of `CompileTypeScriptWithTSConfig`/`TypeScriptDeleteOutputFromOtherConfigs`), so the old hooks would have silently stopped firing. Rewired: the package's own compile is blocked, `CompileTypeScriptRuntime` lints + compiles once in the outer cross-target build (same design as before), `CreateLibFiles` bundles after `PrepareResources` (verified against `_GenerateCompileInputs` in the SDK). Removed the now-obsolete workarounds (`FixDeniedAccessOnDelete`, `BlockTypeScriptInInnerBuilds`, the never-firing `TSLint` target, the Visual Studio TypeScript SDK imports) and the duplicated lint step.

### `src/Web/WebDrapo` (demo components)
- `Microsoft.TypeScript.MSBuild` 7.0.1 compiles `wwwroot/components/**/*.ts` with the native compiler. `tsconfig.json`: target es5 → es2015, `types: ["drapo"]` (TS 7 no longer auto-includes `@types`, and the components use `DrapoApplication`).
- The 7.x package appends `TypeScriptTarget`/`TypeScriptSourceMap` property defaults to the tsc command line where they would override `tsconfig.json` (it would have silently emitted ES2020 + `.js.map` files into `wwwroot`). Both are cleared in the csproj so `tsconfig.json` stays authoritative.
- Clean workaround adapted to the new `tsc-emitted.txt` log. Unused `tslint` devDependency dropped (it cannot run against TS 7 there anyway).

### `src/Extension`
- `typescript` 7.0.2; `module: "none"` removed (no longer accepted; the sources are plain scripts so it changes nothing), `rootDir: "src"` added to keep the `dist/` layout.

### Docs
CLAUDE.md, COPILOT.md, copilot-instructions, the constitution, `doc/architecture.md`, `doc/development.md`, README: commands are now `npm run lint` / `npm run compile`; architecture doc explains the TS 7 specifics.

## Browser support
The production bundle moves from ES5 to **ES2015** syntax (native classes, `let`/`const`, arrow functions; `async`/`await` is still downlevelled to generators). Every browser that supports ES2015 classes also has a native `Promise`, so nothing on the README's supported list (Chrome, Firefox, Safari, Edge) is affected. The only browser that loses support is Internet Explorer 11, which cannot be targeted by TypeScript 7 at all. The `es6-promise` polyfill is still bundled, so the shipped `drapo.js` keeps the same contents apart from the compiled runtime. Debug builds already targeted ES2022 before this change, so the runtime has been running on modern syntax in local testing all along.

## Verification
- `dotnet build Drapo.sln` in **Debug** and **Release** (clean builds), all four target frameworks; embedded `drapo.js` / `drapo.min.js` / `.map` resources present with the names the middleware looks up.
- Gates still fail the build: a TSLint violation fails Release (`npm run lint` exit 2 → MSB3073), a TS type error fails Debug/Release, a component type error fails WebDrapo.
- `dotnet clean` keeps the component `.js` files (the static-web-assets workaround still works); TSLint with the wrapper reports violations correctly.
- Extension: `npm test` 10/10.
- **Full Selenium suite, 356/356 green, three times**: against a Debug WebDrapo (ES2022 dev output), a Release WebDrapo serving the unminified ES2015 `drapo.js`, and a Release WebDrapo in the Production environment serving `drapo.min.js` (uglify-js output). One timing-sensitive test (`MessageSendValueTest`, iframe + postMessage) failed once in the first Debug run and passed in every rerun, including a second full Debug run.
- No test page was added: this is a toolchain change with no `d-*` behaviour change; the existing 356 pages are the coverage.

## Notes for reviewers / follow-ups
- Build agents need Node.js ≥ 16.20 and a supported platform (win/linux/mac x64/arm64) for the native binaries; the Azure pipeline already runs `npm install` in both directories.
- TSLint is unmaintained; a future migration to ESLint/typescript-eslint would also need the `@typescript/typescript6` API until typescript-eslint supports TS 7 natively. Out of scope here.
- `es6-promise` could be dropped now that ES2015 is the floor; kept to keep this PR behaviour-neutral.
- Single-framework builds (`dotnet build -f net10.0`) reuse the `js/` output of the last full build, exactly as before (the SDK flags them as inner builds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PoCkvgpwqmvxSX7bYCLrTX
