### PR TITLE
build(682): minify drapo.min.js with compress+mangle and target ES2017

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,7 +503,7 @@ When reporting bugs or requesting features:
   - .NET 6.0  
   - .NET Core 3.1
 - **Browser Support**: Modern browsers (Chrome, Firefox, Safari, Edge) — the runtime is
-  compiled to ES2015
+  compiled to ES2017 (Chrome 55+, Firefox 52+, Safari 11+, Edge 15+)
 
 ## 📄 License
 

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -20,10 +20,10 @@ JavaScript. It ships as two cooperating parts:
 
 | Area | Technology |
 |------|------------|
-| Client runtime | TypeScript 7.0.2 (native compiler) → `drapo.js`; production target ES2015, development target ES2022 |
+| Client runtime | TypeScript 7.0.2 (native compiler) → `drapo.js`; production target ES2017, development target ES2022 |
 | Client lint | TSLint 6.1.3 (`tslint.json`), running on the `@typescript/typescript6` compiler API via `scripts/tslint.cjs` |
 | Real-time | `@microsoft/signalr` 3.1.17 (WebSocket pipes) |
-| Minification | `uglify-js` |
+| Minification | `uglify-js` (compress + mangle) |
 | Server | ASP.NET Core middleware in C# |
 | Target frameworks | `netcoreapp3.1`, `netcoreapp6.0`, `net8.0`, `net10.0` |
 | .NET SDK | `10.0.100` (pinned in `global.json`, `rollForward: latestFeature`) |
@@ -108,13 +108,14 @@ package also lints and compiles the runtime. The commands live in
 `node_modules`:
 
 - **Release** builds run `npm run lint` (TSLint) and then `npm run compile`
-  (`tsconfig/production/tsconfig.json`, target ES2015).
+  (`tsconfig/production/tsconfig.json`, target ES2017, native async/await).
 - **Debug** builds run `npm run compile:dev` (`tsconfig/development/tsconfig.json`,
   target ES2022, source maps).
 - TypeScript is compiled **once** in the outer (cross-target) build before the
   per-framework inner builds run in parallel, avoiding races on the shared `js/`
   output. Each inner build then bundles `js/` with the runtime dependencies into
-  `lib/<tfm>/drapo.js`, minifies it with `uglify-js`, and embeds both files.
+  `lib/<tfm>/drapo.js`, minifies it with `uglify-js -c -m` (local names are mangled; top-level names such as the
+  `Drapo*` classes are kept), and embeds both files.
 - The `Microsoft.TypeScript.MSBuild` package (7.x) is referenced for the Visual Studio
   integration only; its own compilation is blocked (`TypeScriptCompileBlocked`) so the
   runtime is never compiled twice. `WebDrapo` does use that package to compile its
@@ -123,9 +124,11 @@ package also lints and compiles the runtime. The commands live in
 **TypeScript 7 notes.** The native compiler has no JavaScript API and no ES5 target.
 TSLint needs that API, so `scripts/tslint.cjs` redirects its `require('typescript')`
 to Microsoft's `@typescript/typescript6` compatibility package while `tsc` itself is
-TypeScript 7. The production output moved from ES5 to ES2015 (the lowest target
-TypeScript 7 supports); every browser that supports ES2015 classes also has native
-`Promise`, and the bundled `es6-promise` polyfill remains for backward compatibility.
+TypeScript 7. The production output moved from ES5 to ES2017 (TypeScript 7 supports
+ES2015 and up; ES2017 additionally keeps `async`/`await` native instead of compiling
+every async function into a generator state machine). Every browser that runs ES2017
+also has a native `Promise`; the bundled `es6-promise` polyfill remains for backward
+compatibility.
 
 This is why **TSLint passing is a hard gate**: a Release build will fail if it doesn't.
 See [development.md](development.md) for the exact commands.

--- a/doc/development.md
+++ b/doc/development.md
@@ -34,7 +34,7 @@ cd src/Middleware/Drapo && npm install
 cd src/Middleware/Drapo && npm run lint
 
 # Compile the TypeScript runtime directly (optional; the build also does this)
-cd src/Middleware/Drapo && npm run compile       # production tsconfig (ES2015, no source maps)
+cd src/Middleware/Drapo && npm run compile       # production tsconfig (ES2017, no source maps)
 cd src/Middleware/Drapo && npm run compile:dev   # development tsconfig (ES2022, source maps)
 
 # Build the full solution

--- a/src/Middleware/Drapo/Drapo.csproj
+++ b/src/Middleware/Drapo/Drapo.csproj
@@ -47,7 +47,9 @@
 	     step before that. -->
 	<Target Name="CreateLibFiles" AfterTargets="PrepareResources" Condition="'$(BuildingProject)' == 'true' AND '$(DesignTimeBuild)' != 'true'">
 		<Exec Command="node scripts/create-lib.mjs $(TargetFramework)" />
-		<Exec Command="npx uglify-js lib/$(TargetFramework)/drapo.js -o lib/$(TargetFramework)/drapo.min.js" />
+		<!-- compress (-c) and mangle local names (-m); top-level names such as the Drapo* classes are kept, so component
+		     scripts and page code that reach the runtime through globals are unaffected. -->
+		<Exec Command="npx uglify-js lib/$(TargetFramework)/drapo.js -c -m -o lib/$(TargetFramework)/drapo.min.js" />
 		<WriteLinesToFile File="lib\$(TargetFramework)\drapo.min.js" Lines="%0a//# sourceMappingURL=drapo.js.map" Overwrite="false" />
 		<ItemGroup>
 			<EmbeddedResource Include="lib\$(TargetFramework)\*.js" WithCulture="false" Type="Non-Resx" />

--- a/src/Middleware/Drapo/tsconfig/production/tsconfig.json
+++ b/src/Middleware/Drapo/tsconfig/production/tsconfig.json
@@ -9,14 +9,14 @@
     "noEmitOnError": true,
     "removeComments": true,
     "sourceMap": false,
-    "target": "es2015",
+    "target": "es2017",
     "rootDir": "../../ts/",
     "outDir": "../../js/",
     "declaration": true,
     "types": [],
     "lib": [
       "dom",
-      "es2015"
+      "es2017"
     ]
   },
   "exclude": [


### PR DESCRIPTION
Closes #682

## What changed
- **uglify-js now runs with `-c -m`.** It ran with no options before, so the "minified" bundle only had whitespace removed. Local names are mangled; top-level names (the `Drapo*` classes, `window.drapo`) are kept because uglify does not touch top-level scope without `--toplevel`, so component scripts that resolve constructors through `window[...]` (`DrapoRegister`) and page code are unaffected. The runtime has no `eval`/`new Function` and does not read `.name` on functions.
- **Production target ES2015 → ES2017** (`tsconfig/production`). The ~570 async functions / ~1,370 awaits are now native `async`/`await` instead of `__awaiter` + generator state machines (640 occurrences removed). Browser floor moves from 2016 to 2017 releases: Chrome 55, Firefox 52, Safari 11, Edge 15. Debug builds were already ES2022.
- Docs updated (architecture, development, README browser line).

## Result (net10.0 bundle, includes the SignalR client and es6-promise)

| File | Before | After |
|---|---|---|
| `drapo.js` | 1,105,104 | 1,010,027 |
| `drapo.min.js` | 806,498 | **487,027** (104,436 gzipped) |

## Verification
- `dotnet build Drapo.sln -c Release`: green.
- Full Selenium suite **356/356** against a Release WebDrapo serving `drapo.js`, and **356/356** against a Production-environment WebDrapo serving the mangled `drapo.min.js`.
- No test page added: no `d-*` behaviour change; the 356 existing pages are the coverage for the mangled output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PoCkvgpwqmvxSX7bYCLrTX
