### PR TITLE
feat(683): serve drapo.js and drapo.js.map brotli/gzip compressed

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,21 @@ public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
 
 **Gateway Support**: The origin validation automatically supports scenarios where an external gateway or load balancer handles HTTPS, while the internal application runs on HTTP. Only the host/domain portion is compared, not the scheme.
 
+#### Runtime compression
+
+The middleware serves `drapo.js` (and `drapo.js.map` in debug mode) brotli- or gzip-compressed to
+browsers that send a matching `Accept-Encoding`, with one ETag per representation and
+`Vary: Accept-Encoding`. The compressed variants are produced once per process, in the background,
+at startup. This is on by default; turn it off when a reverse proxy or another middleware already
+compresses responses:
+
+```csharp
+app.UseDrapo(options =>
+{
+    options.UseCompression = false;
+});
+```
+
 #### Default Behavior
 
 - **Origin validation is enabled by default** for security

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -132,7 +132,10 @@ See [development.md](development.md) for the exact commands.
 
 ## Request/data flow (high level)
 
-1. The browser loads a page that includes `<script src="/drapo.js"></script>`.
+1. The browser loads a page that includes `<script src="/drapo.js"></script>`. The
+   middleware serves the embedded bundle brotli- or gzip-compressed when the browser
+   accepts it (`DrapoMiddlewareOptions.UseCompression`, on by default; see
+   `DrapoCompressedContent`), with a per-representation ETag for revalidation.
 2. `DrapoApplication` boots, scans the DOM, and resolves `d-datakey` data contexts
    (loading from `d-dataurlget`/`d-dataurl` endpoints served by the middleware as needed).
 3. Control-flow attributes (`d-for`, `d-if`) expand the DOM; binding (`{{ }}`, `d-model`)

--- a/src/Middleware/Drapo/DrapoCompressedContent.cs
+++ b/src/Middleware/Drapo/DrapoCompressedContent.cs
@@ -1,0 +1,176 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Sysphera.Middleware.Drapo
+{
+    /// <summary>
+    /// An immutable text resource (drapo.js, drapo.js.map) kept in memory as its identity bytes plus
+    /// gzip and brotli variants. The compressed variants are produced once, on first use (or by
+    /// <see cref="WarmUp"/>), and selected per request from the Accept-Encoding header.
+    /// </summary>
+    internal sealed class DrapoCompressedContent
+    {
+        #region Fields
+        private const string ENCODING_GZIP = "gzip";
+        private const string ENCODING_BROTLI = "br";
+        private readonly DrapoCompressedContentVariant _identity;
+        private readonly Lazy<DrapoCompressedContentVariant> _gzip;
+        private readonly Lazy<DrapoCompressedContentVariant> _brotli;
+        #endregion
+        #region Properties
+        public DrapoCompressedContentVariant Identity
+        {
+            get
+            {
+                return (this._identity);
+            }
+        }
+        #endregion
+        #region Constructors
+        public DrapoCompressedContent(string content, Func<byte[], string> generateETag)
+        {
+            byte[] identity = Encoding.UTF8.GetBytes(content ?? string.Empty);
+            string eTag = generateETag(identity);
+            this._identity = new DrapoCompressedContentVariant(identity, null, eTag);
+            this._gzip = new Lazy<DrapoCompressedContentVariant>(() => new DrapoCompressedContentVariant(Compress(identity, ENCODING_GZIP), ENCODING_GZIP, eTag + "-" + ENCODING_GZIP), LazyThreadSafetyMode.ExecutionAndPublication);
+            this._brotli = new Lazy<DrapoCompressedContentVariant>(() => new DrapoCompressedContentVariant(Compress(identity, ENCODING_BROTLI), ENCODING_BROTLI, eTag + "-" + ENCODING_BROTLI), LazyThreadSafetyMode.ExecutionAndPublication);
+        }
+        #endregion
+        #region Select
+        /// <summary>
+        /// Picks the best variant the client accepts: brotli, then gzip, otherwise the identity bytes.
+        /// </summary>
+        /// <param name="acceptEncoding">The raw Accept-Encoding request header (null or empty means identity).</param>
+        public DrapoCompressedContentVariant Select(string acceptEncoding)
+        {
+            if (string.IsNullOrWhiteSpace(acceptEncoding))
+                return (this._identity);
+            if (Accepts(acceptEncoding, ENCODING_BROTLI))
+                return (this._brotli.Value);
+            if (Accepts(acceptEncoding, ENCODING_GZIP))
+                return (this._gzip.Value);
+            return (this._identity);
+        }
+
+        /// <summary>
+        /// Produces the compressed variants ahead of the first request. Safe to call from a background task.
+        /// </summary>
+        public void WarmUp()
+        {
+            DrapoCompressedContentVariant gzip = this._gzip.Value;
+            DrapoCompressedContentVariant brotli = this._brotli.Value;
+        }
+
+        public Task WarmUpAsync()
+        {
+            return (Task.Run(() =>
+            {
+                try
+                {
+                    this.WarmUp();
+                }
+                catch
+                {
+                    // A failed warm-up is not fatal: the variant is retried lazily on the first request that needs it.
+                }
+            }));
+        }
+
+        private static bool Accepts(string acceptEncoding, string encoding)
+        {
+            // Accept-Encoding: gzip, deflate, br;q=1.0, identity;q=0.5, *;q=0
+            string[] entries = acceptEncoding.Split(',');
+            for (int i = 0; i < entries.Length; i++)
+            {
+                string[] parts = entries[i].Split(';');
+                string name = parts[0].Trim();
+                if (!string.Equals(name, encoding, StringComparison.OrdinalIgnoreCase))
+                    continue;
+                for (int j = 1; j < parts.Length; j++)
+                {
+                    string parameter = parts[j].Trim();
+                    if (!parameter.StartsWith("q=", StringComparison.OrdinalIgnoreCase))
+                        continue;
+                    double quality;
+                    if ((double.TryParse(parameter.Substring(2), System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out quality)) && (quality <= 0))
+                        return (false);
+                }
+                return (true);
+            }
+            return (false);
+        }
+        #endregion
+        #region Compress
+        private static byte[] Compress(byte[] data, string encoding)
+        {
+            using (MemoryStream output = new MemoryStream())
+            {
+                using (Stream compressor = CreateCompressor(output, encoding))
+                    compressor.Write(data, 0, data.Length);
+                return (output.ToArray());
+            }
+        }
+
+        private static Stream CreateCompressor(Stream output, string encoding)
+        {
+            // The content is compressed once and served for the lifetime of the process, so the slowest
+            // (smallest) level pays off. SmallestSize exists from .NET 6; on netcoreapp3.1 Optimal is the same level.
+#if NET6_0_OR_GREATER
+            CompressionLevel level = CompressionLevel.SmallestSize;
+#else
+            CompressionLevel level = CompressionLevel.Optimal;
+#endif
+            if (encoding == ENCODING_BROTLI)
+                return (new BrotliStream(output, level, true));
+            return (new GZipStream(output, level, true));
+        }
+        #endregion
+    }
+
+    internal sealed class DrapoCompressedContentVariant
+    {
+        #region Fields
+        private readonly byte[] _bytes;
+        private readonly string _contentEncoding;
+        private readonly string _eTag;
+        #endregion
+        #region Properties
+        public byte[] Bytes
+        {
+            get
+            {
+                return (this._bytes);
+            }
+        }
+
+        /// <summary>The Content-Encoding to send, or null for the identity (uncompressed) bytes.</summary>
+        public string ContentEncoding
+        {
+            get
+            {
+                return (this._contentEncoding);
+            }
+        }
+
+        public string ETag
+        {
+            get
+            {
+                return (this._eTag);
+            }
+        }
+        #endregion
+        #region Constructors
+        public DrapoCompressedContentVariant(byte[] bytes, string contentEncoding, string eTag)
+        {
+            this._bytes = bytes;
+            this._contentEncoding = contentEncoding;
+            this._eTag = eTag;
+        }
+        #endregion
+    }
+}

--- a/src/Middleware/Drapo/DrapoMiddleware.cs
+++ b/src/Middleware/Drapo/DrapoMiddleware.cs
@@ -33,13 +33,11 @@ namespace Sysphera.Middleware.Drapo
         private readonly string _webRootPath = null;
         private readonly string _urlActivator = null;
         private readonly string _urlConfig = null;
-        private string _libContent = null;
-        private string _libETag = null;
+        private DrapoCompressedContent _lib = null;
         private string _libLastModified = null;
         private string _configContent = null;
         private string _configETag = null;
-        private string _jsMapContent = null;
-        private string _jsMapETag = null;
+        private DrapoCompressedContent _jsMap = null;
         private ConcurrentDictionary<string, string> _cacheComponentFileContent = new ConcurrentDictionary<string, string>();
         private ConcurrentDictionary<string, string> _cachePackContent = new ConcurrentDictionary<string, string>();
         private ConcurrentDictionary<string, string> _cachePackETag = new ConcurrentDictionary<string, string>();
@@ -72,10 +70,14 @@ namespace Sysphera.Middleware.Drapo
             if (this._options.UseInternalComponents)
                 InitilizeInternalComponents();
             //Content
-            this._libContent = resources[libName];
-            this._libETag = GenerateETag(Encoding.UTF8.GetBytes(this._libContent));
-            this._jsMapContent = this.CreateJsMapContent(resources);
-            this._jsMapETag = GenerateETag(Encoding.UTF8.GetBytes(this._jsMapContent));
+            this._lib = new DrapoCompressedContent(resources[libName], GenerateETag);
+            this._jsMap = new DrapoCompressedContent(this.CreateJsMapContent(resources, resources[libName]), GenerateETag);
+            if (this._options.UseCompression)
+            {
+                // Produce the gzip/brotli variants in the background so no request pays the one-time compression cost.
+                _ = this._lib.WarmUpAsync();
+                _ = this._jsMap.WarmUpAsync();
+            }
             this._configContent = this.GetConfigContent();
             this._configETag = GenerateETag(Encoding.UTF8.GetBytes(this._configContent));
             this._libLastModified = System.IO.File.GetLastWriteTime(System.Reflection.Assembly.GetEntryAssembly().Location).ToString("R");
@@ -104,28 +106,12 @@ namespace Sysphera.Middleware.Drapo
             if (this.IsActivator(context))
             {
                 //JS
-                bool isCache = ((context.Request.Headers.ContainsKey("If-None-Match")) && (context.Request.Headers["If-None-Match"].ToString() == this._libETag));
-                context.Response.StatusCode = isCache ? (int)HttpStatusCode.NotModified : (int)HttpStatusCode.OK;
-                context.Response.Headers["ETag"] = new[] { this._libETag };
-                context.Response.Headers.Add("Last-Modified", new[] { this._libLastModified });
-                context.Response.Headers.Add("Cache-Control", new[] { "no-cache" });
-                context.Response.Headers.Add("Content-Type", new[] { "text/javascript" });
-                AppendHeaderContainerId(context);
-                if (!isCache)
-                    await context.Response.WriteAsync(this._libContent);
+                await this.WriteCompressedContentAsync(context, this._lib, "text/javascript");
             }
             else if (this.IsJsMapActivator(context))
             {
                 //.JS.MAP
-                bool isCache = ((context.Request.Headers.ContainsKey("If-None-Match")) && (context.Request.Headers["If-None-Match"].ToString() == this._jsMapETag));
-                context.Response.StatusCode = isCache ? (int)HttpStatusCode.NotModified : (int)HttpStatusCode.OK;
-                context.Response.Headers["ETag"] = new[] { this._jsMapETag };
-                context.Response.Headers.Add("Last-Modified", new[] { this._libLastModified });
-                context.Response.Headers.Add("Cache-Control", new[] { "no-cache" });
-                context.Response.Headers.Add("Content-Type", new[] { "application/json" });
-                AppendHeaderContainerId(context);
-                if (!isCache)
-                    await context.Response.WriteAsync(this._jsMapContent);
+                await this.WriteCompressedContentAsync(context, this._jsMap, "application/json");
             }
             else if (this.IsConfig(context))
             {
@@ -229,6 +215,32 @@ namespace Sysphera.Middleware.Drapo
             return (!string.IsNullOrEmpty(this._options.Config.HeaderContainerId));
         }
 
+        /// <summary>
+        /// Serves an in-memory resource with ETag/If-None-Match handling. When compression is enabled and the client
+        /// accepts brotli or gzip, the pre-compressed variant is written with the matching Content-Encoding; each variant
+        /// has its own ETag so a cached compressed copy is revalidated against the same representation.
+        /// </summary>
+        private async Task WriteCompressedContentAsync(HttpContext context, DrapoCompressedContent content, string contentType)
+        {
+            string acceptEncoding = this._options.UseCompression ? context.Request.Headers["Accept-Encoding"].ToString() : null;
+            DrapoCompressedContentVariant variant = content.Select(acceptEncoding);
+            bool isCache = ((context.Request.Headers.ContainsKey("If-None-Match")) && (context.Request.Headers["If-None-Match"].ToString() == variant.ETag));
+            context.Response.StatusCode = isCache ? (int)HttpStatusCode.NotModified : (int)HttpStatusCode.OK;
+            context.Response.Headers["ETag"] = new[] { variant.ETag };
+            context.Response.Headers.Add("Last-Modified", new[] { this._libLastModified });
+            context.Response.Headers.Add("Cache-Control", new[] { "no-cache" });
+            context.Response.Headers.Add("Content-Type", new[] { contentType });
+            if (this._options.UseCompression)
+                context.Response.Headers["Vary"] = new[] { "Accept-Encoding" };
+            if (variant.ContentEncoding != null)
+                context.Response.Headers["Content-Encoding"] = new[] { variant.ContentEncoding };
+            AppendHeaderContainerId(context);
+            if (isCache)
+                return;
+            context.Response.ContentLength = variant.Bytes.Length;
+            await context.Response.Body.WriteAsync(variant.Bytes, 0, variant.Bytes.Length);
+        }
+
         private void AppendHeaderContainerId(HttpContext httpContext)
         {
             string headerContainerId = this._options.Config.HeaderContainerId;
@@ -294,11 +306,11 @@ namespace Sysphera.Middleware.Drapo
 
         private static string GetThisSourceFilePath([CallerFilePath] string path = null) => path;
 
-        private string CreateJsMapContent(Dictionary<string, string> resources)
+        private string CreateJsMapContent(Dictionary<string, string> resources, string libContent)
         {
             //collect line offsets
             List<(string jsMapFilename, int lineOffset)> jsMapsOffsets = new List<(string jsMapFilename, int offset)>();
-            string[] libLines = this._libContent.Split('\n');
+            string[] libLines = libContent.Split('\n');
             int currentOffset = 0;
             for (int lineNumber = 0; lineNumber < libLines.Length; ++lineNumber)
             {

--- a/src/Middleware/Drapo/DrapoMiddlewareOptions.cs
+++ b/src/Middleware/Drapo/DrapoMiddlewareOptions.cs
@@ -29,6 +29,12 @@ namespace Sysphera.Middleware.Drapo
         #region Properties
         public bool Debug { set; get;}
         public bool UseInternalComponents { set; get; }
+        /// <summary>
+        /// When true (the default) drapo.js and drapo.js.map are served brotli- or gzip-compressed to clients that
+        /// send a matching Accept-Encoding header. Set to false when a reverse proxy or another middleware already
+        /// compresses responses and you want the middleware to emit the identity bytes only.
+        /// </summary>
+        public bool UseCompression { set; get; }
         public string BackplaneRedis { set; get; }
         public string ContainerUrl { set; get; }
         public DrapoConfig Config
@@ -43,6 +49,7 @@ namespace Sysphera.Middleware.Drapo
             public DrapoMiddlewareOptions()
             {
                 this.UseInternalComponents = true;
+                this.UseCompression = true;
             }
         #endregion
 

--- a/src/Test/WebDrapo.Test/CompressionTest.cs
+++ b/src/Test/WebDrapo.Test/CompressionTest.cs
@@ -1,0 +1,145 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace WebDrapo.Test
+{
+    /// <summary>
+    /// Verifies that the middleware serves drapo.js compressed according to Accept-Encoding, keeps one ETag per
+    /// representation, and still answers 304 Not Modified for revalidation of a compressed copy.
+    /// Runs against the same WebDrapo instance as the Selenium tests (WebDrapoURL run setting).
+    /// </summary>
+    [TestFixture]
+    public class CompressionTest
+    {
+        #region Fields
+        private string _url = null;
+        private HttpClient _client = null;
+        #endregion
+
+        #region Setup
+        [OneTimeSetUp]
+        public void Setup()
+        {
+            string virtualDirectory = TestContext.Parameters["WebDrapoURL"] ?? "http://localhost:9991/";
+            this._url = virtualDirectory + "drapo.js";
+            this._client = new HttpClient(new HttpClientHandler() { AutomaticDecompression = DecompressionMethods.None });
+        }
+
+        [OneTimeTearDown]
+        public void TearDown()
+        {
+            this._client.Dispose();
+        }
+        #endregion
+
+        #region Helpers
+        private async Task<HttpResponseMessage> GetAsync(string acceptEncoding, string ifNoneMatch = null)
+        {
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, this._url);
+            if (acceptEncoding != null)
+                request.Headers.TryAddWithoutValidation("Accept-Encoding", acceptEncoding);
+            if (ifNoneMatch != null)
+                request.Headers.TryAddWithoutValidation("If-None-Match", ifNoneMatch);
+            return (await this._client.SendAsync(request));
+        }
+
+        // The middleware emits the ETag without quotes (the runtime relies on that format), which the typed
+        // HttpResponseHeaders.ETag parser rejects, so read the raw header value.
+        private static string ETag(HttpResponseMessage response)
+        {
+            System.Collections.Generic.IEnumerable<string> values;
+            if (!response.Headers.TryGetValues("ETag", out values))
+                return (null);
+            return (string.Join(",", values));
+        }
+
+        private static string ContentEncoding(HttpResponseMessage response)
+        {
+            return (string.Join(",", response.Content.Headers.ContentEncoding));
+        }
+
+        private static async Task<byte[]> Decompress(HttpResponseMessage response)
+        {
+            byte[] body = await response.Content.ReadAsByteArrayAsync();
+            string encoding = ContentEncoding(response);
+            if (encoding == string.Empty)
+                return (body);
+            using (MemoryStream input = new MemoryStream(body))
+            using (Stream decompressor = encoding == "br" ? (Stream)new BrotliStream(input, CompressionMode.Decompress) : new GZipStream(input, CompressionMode.Decompress))
+            using (MemoryStream output = new MemoryStream())
+            {
+                await decompressor.CopyToAsync(output);
+                return (output.ToArray());
+            }
+        }
+        #endregion
+
+        #region Tests
+        [Test]
+        public async Task CompressionIdentityTest()
+        {
+            HttpResponseMessage response = await this.GetAsync(null);
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(ContentEncoding(response), Is.EqualTo(string.Empty));
+            Assert.That(response.Headers.Vary, Does.Contain("Accept-Encoding"));
+            Assert.That(ETag(response), Is.Not.Null.And.Not.Empty);
+            Assert.That(ETag(response), Does.Not.Contain("-"));
+            byte[] body = await response.Content.ReadAsByteArrayAsync();
+            Assert.That(body.Length, Is.EqualTo(response.Content.Headers.ContentLength));
+            Assert.That(body.Length, Is.GreaterThan(0));
+        }
+
+        [TestCase("gzip", "gzip")]
+        [TestCase("br", "br")]
+        [TestCase("gzip, deflate, br", "br")]
+        [TestCase("br;q=0, gzip", "gzip")]
+        [TestCase("gzip;q=0.8, br;q=0.5", "br")]
+        public async Task CompressionVariantTest(string acceptEncoding, string expectedEncoding)
+        {
+            HttpResponseMessage identity = await this.GetAsync(null);
+            byte[] identityBody = await identity.Content.ReadAsByteArrayAsync();
+            HttpResponseMessage response = await this.GetAsync(acceptEncoding);
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(ContentEncoding(response), Is.EqualTo(expectedEncoding));
+            Assert.That(response.Headers.Vary, Does.Contain("Accept-Encoding"));
+            Assert.That(ETag(response), Is.EqualTo(ETag(identity) + "-" + expectedEncoding));
+            byte[] compressed = await response.Content.ReadAsByteArrayAsync();
+            Assert.That(compressed.Length, Is.EqualTo(response.Content.Headers.ContentLength));
+            Assert.That(compressed.Length, Is.LessThan(identityBody.Length / 4));
+            byte[] decompressed = await Decompress(response);
+            Assert.That(decompressed, Is.EqualTo(identityBody));
+        }
+
+        [TestCase(null)]
+        [TestCase("gzip")]
+        [TestCase("br")]
+        public async Task CompressionNotModifiedTest(string acceptEncoding)
+        {
+            HttpResponseMessage first = await this.GetAsync(acceptEncoding);
+            string eTag = ETag(first);
+            HttpResponseMessage second = await this.GetAsync(acceptEncoding, eTag);
+            Assert.That(second.StatusCode, Is.EqualTo(HttpStatusCode.NotModified));
+            Assert.That(ETag(second), Is.EqualTo(eTag));
+            byte[] body = await second.Content.ReadAsByteArrayAsync();
+            Assert.That(body.Length, Is.EqualTo(0));
+        }
+
+        [Test]
+        public async Task CompressionETagIsPerRepresentationTest()
+        {
+            HttpResponseMessage gzip = await this.GetAsync("gzip");
+            HttpResponseMessage brotli = await this.GetAsync("br");
+            // A copy cached under the gzip ETag must not be revalidated as the brotli representation.
+            HttpResponseMessage response = await this.GetAsync("br", ETag(gzip));
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(ContentEncoding(response), Is.EqualTo("br"));
+            Assert.That(ETag(response), Is.EqualTo(ETag(brotli)));
+        }
+        #endregion
+    }
+}


### PR DESCRIPTION
Closes #683

## What changed
- **`DrapoCompressedContent`** (new, internal): holds a text resource as identity bytes plus lazily produced gzip and brotli variants (highest compression level; `SmallestSize` on .NET 6+, `Optimal` on netcoreapp3.1 which is the same level). Variant selection parses `Accept-Encoding` with q-values (`br;q=0, gzip` → gzip). Each variant carries its own ETag: `<etag>`, `<etag>-gzip`, `<etag>-br`.
- **`DrapoMiddleware`**: `drapo.js` and `drapo.js.map` go through one `WriteCompressedContentAsync` path that keeps the existing ETag / `If-None-Match` → 304 behaviour, adds `Vary: Accept-Encoding` and `Content-Encoding`, and writes the bytes with `Content-Length`. The variants are warmed in a background task at startup so no request pays the one-time compression cost (brotli at max level takes ~0.6 s for the bundle; gzip ~10 ms).
- **`DrapoMiddlewareOptions.UseCompression`** (default `true`): set to `false` when a reverse proxy or response-compression middleware already handles it. With it off the response is byte-for-byte what it was before.
- Docs: README "Runtime compression" section, architecture request-flow note.

The ETag format (unquoted MD5) is unchanged; only the suffix is new for compressed representations.

## Result (`drapo.min.js`, current master)

| Encoding | Bytes |
|---|---|
| identity (before, and still for clients without `Accept-Encoding`) | 806,498 |
| gzip | ~130,000 |
| **br** | **107,214** |

With #685 (compress+mangle, ES2017) merged as well, the brotli response is ~86 KB.

## Verification
- `dotnet build Drapo.sln` Debug and Release, all four target frameworks.
- **New `CompressionTest` fixture** (10 cases) in `WebDrapo.Test`, run against the same WebDrapo instance as the Selenium tests: identity response and headers; variant selection for `gzip`, `br`, `gzip, deflate, br`, `br;q=0, gzip`, `gzip;q=0.8, br;q=0.5`; decompressed body equals the identity body; `Content-Length` matches; 304 for each representation with its own ETag; a gzip ETag does not revalidate the brotli representation.
- **Full suite 366/366** (356 Selenium + 10 new) against Debug and against a Production-environment Release WebDrapo. Chrome negotiates brotli, so every Selenium page now loads the runtime through the compressed path.
- Manual `curl` checks of each `Accept-Encoding` value, 304 with the `-br` ETag, and `gzip -d` of the gzip body matching the identity MD5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PoCkvgpwqmvxSX7bYCLrTX
