### PR TITLE
test: make MessageSendValueTest deterministic

### DIFF
--- a/src/Test/WebDrapo.Test/Pages/MessageSendValue.Test.html
+++ b/src/Test/WebDrapo.Test/Pages/MessageSendValue.Test.html
@@ -8,7 +8,9 @@
 		<div d-datakey="itemObject" d-datatype="object" d-dataproperty-value-name="Value" d-dataproperty-value-value="OldValue"></div>
 		<div d-datakey="valueFromMessage" d-datatype="value"></div>
 		<div d-datakey="updateItemValue" d-datatype="value" d-datavalue="UpdateDataField(itemObject,Value,{{valueFromMessage}})"></div>
-		<span d-model="{{itemObject.Value}}" driverunittest="click">NewValue</span>
+		<span d-model="{{itemObject.Value}}">NewValue</span>
+		<!-- The harness clicks input[driverunittest=click] and then waits 5s, which gives the iframe message time to be processed after drapo._isLoaded -->
+		<input type="button" value="Wait" driverunittest="click">
 		<iframe id="frameID" src="MessageSendValueSector.html"></iframe>
 	</div>
 

--- a/src/Web/WebDrapo/wwwroot/DrapoPages/MessageSendValue.html
+++ b/src/Web/WebDrapo/wwwroot/DrapoPages/MessageSendValue.html
@@ -10,7 +10,9 @@
 		<div d-dataKey="itemObject" d-dataType="object" d-dataProperty-value-name="Value" d-dataProperty-value-value="OldValue"></div>
 		<div d-dataKey="valueFromMessage" d-dataType="value"></div>
 		<div d-dataKey="updateItemValue" d-dataType="value" d-dataValue="UpdateDataField(itemObject,Value,{{valueFromMessage}})"></div>
-		<span d-model="{{itemObject.Value}}" driverunittest="click"></span>
+		<span d-model="{{itemObject.Value}}"></span>
+		<!-- The harness clicks input[driverunittest=click] and then waits 5s, which gives the iframe message time to be processed after drapo._isLoaded -->
+		<input type="button" value="Wait" driverunittest="click" />
 		<iframe id="frameID" src="MessageSendValueSector.html"></iframe>
 	</div>
 </body>


### PR DESCRIPTION
## Why
`MessageSendValueTest` failed intermittently in full suite runs (3 times during the TypeScript 7 and follow-up work: `OldValue` instead of `NewValue`), always passing in isolation.

Root cause is in the test page, not the runtime: `driverunittest="click"` was on a `<span>`, but `ValidatePage` only clicks `//input[@driverunittest='click']` and only then sleeps 5 s. So the snapshot was taken within 100 ms of `drapo._isLoaded`, while the runtime deliberately defers the iframe's `execute` message until `_isLoaded` is true (`DrapoDocument.ExecuteMessage`). Whether the message's `UpdateDataField` landed before the snapshot depended on machine load.

## Change
The wait now sits on an `<input type="button" driverunittest="click">` so the harness performs it; the `d-model` span keeps its role. Expected snapshot updated to match.

## Verification
- The test alone: 3/3, now ~5 s each (the intended wait).
- Full suite: 3 consecutive runs 356/356. One earlier full run on this branch reported the test failing in 109 ms, i.e. before the new page's runtime could have initialised (the unit-test hook waits ≥500 ms for the pipe connection); it did not reproduce in the following three runs and its output was not captured. Noting it for transparency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PoCkvgpwqmvxSX7bYCLrTX
