### PR TITLE
build(684): drop es6-promise and upgrade the SignalR client to 10.0.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,7 +503,8 @@ When reporting bugs or requesting features:
   - .NET 6.0  
   - .NET Core 3.1
 - **Browser Support**: Modern browsers (Chrome, Firefox, Safari, Edge) — the runtime is
-  compiled to ES2017 (Chrome 55+, Firefox 52+, Safari 11+, Edge 15+)
+  compiled to ES2017 and bundled with an ES2019 SignalR client (Chrome 66+, Firefox 58+,
+  Safari 11.1+, Edge 79+)
 
 ## 📄 License
 

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -22,7 +22,7 @@ JavaScript. It ships as two cooperating parts:
 |------|------------|
 | Client runtime | TypeScript 7.0.2 (native compiler) → `drapo.js`; production target ES2017, development target ES2022 |
 | Client lint | TSLint 6.1.3 (`tslint.json`), running on the `@typescript/typescript6` compiler API via `scripts/tslint.cjs` |
-| Real-time | `@microsoft/signalr` 3.1.17 (WebSocket pipes) |
+| Real-time | `@microsoft/signalr` 10.0.11 browser build (WebSocket pipes); its ES2019 syntax sets the floor of the bundle |
 | Minification | `uglify-js` (compress + mangle) |
 | Server | ASP.NET Core middleware in C# |
 | Target frameworks | `netcoreapp3.1`, `netcoreapp6.0`, `net8.0`, `net10.0` |
@@ -126,9 +126,11 @@ TSLint needs that API, so `scripts/tslint.cjs` redirects its `require('typescrip
 to Microsoft's `@typescript/typescript6` compatibility package while `tsc` itself is
 TypeScript 7. The production output moved from ES5 to ES2017 (TypeScript 7 supports
 ES2015 and up; ES2017 additionally keeps `async`/`await` native instead of compiling
-every async function into a generator state machine). Every browser that runs ES2017
-also has a native `Promise`; the bundled `es6-promise` polyfill remains for backward
-compatibility.
+every async function into a generator state machine). The bundled SignalR client is an
+ES2019 build (optional catch binding, object spread), so the shipped `drapo.js` as a
+whole needs an ES2019 browser: Chrome 66, Firefox 58, Safari 11.1, Chromium Edge 79 or
+newer. The former `es6-promise` polyfill is gone; every such browser has a native
+`Promise`.
 
 This is why **TSLint passing is a hard gate**: a Release build will fail if it doesn't.
 See [development.md](development.md) for the exact commands.

--- a/src/Middleware/Drapo/package.json
+++ b/src/Middleware/Drapo/package.json
@@ -8,9 +8,8 @@
     "compile:dev": "tsc -p tsconfig/development/tsconfig.json"
   },
   "devDependencies": {
-    "@microsoft/signalr": "3.1.17",
+    "@microsoft/signalr": "10.0.11",
     "@typescript/typescript6": "6.0.2",
-    "es6-promise": "4.2.4",
     "tslint": "6.1.3",
     "typescript": "7.0.2",
     "uglify-js": "^3.19.3"

--- a/src/Middleware/Drapo/scripts/create-lib.mjs
+++ b/src/Middleware/Drapo/scripts/create-lib.mjs
@@ -13,8 +13,9 @@ if (!targetFramework) {
 const outputDirectory = resolve(root, 'lib', targetFramework);
 await mkdir(outputDirectory, { recursive: true });
 
+// Runtime dependencies bundled in front of the compiled runtime. The SignalR browser build is ES2019
+// (optional catch binding, object spread), which sets the syntax floor of the whole drapo.js bundle.
 const dependencies = [
-  resolve(root, 'node_modules/es6-promise/dist/es6-promise.auto.min.js'),
   resolve(root, 'node_modules/@microsoft/signalr/dist/browser/signalr.min.js')
 ];
 const jsDirectory = resolve(root, 'js');


### PR DESCRIPTION
Closes #684

> Stacked on #685 (ES2017 target) and #687 (deterministic `MessageSendValueTest`); once those merge, this PR shows only its own commit.

## What changed
- **es6-promise removed** from the bundle and `package.json`. Every browser the ES2017 runtime can run on has a native `Promise`; the polyfill only cost parse time.
- **`@microsoft/signalr` 3.1.17 → 10.0.11.** The browser build is 48 KB instead of 122 KB. The runtime uses only the stable builder API (`withUrl` with `skipNegotiation` + WebSockets, `withAutomaticReconnect`, `start`, `on`, `onreconnected`, `invoke`), all unchanged. Negotiation is skipped, so the client talks the JSON hub protocol v1 handshake directly, which is what every supported server version (netcoreapp3.1 … net10.0) speaks.
- `scripts/create-lib.mjs` bundles only the SignalR client now, with a comment about the syntax floor.
- Docs: architecture tech table and TS notes, README browser line.

## Browser floor: read this part
SignalR 8, 9 and 10 browser builds all need **ES2019** (optional catch binding and object spread; verified by parsing with acorn at each ECMAScript level). Because the client is concatenated into `drapo.js`, a pre-ES2019 browser fails to parse the whole file. The practical floor of the shipped bundle therefore moves from 2017 releases to **Chrome 66, Firefox 58, Safari 11.1, Chromium Edge 79** (2018 releases; legacy EdgeHTML Edge, retired in 2021, is out). The runtime's own target stays ES2017. If that floor is not acceptable, the alternative is to stay on the 3.1.x client (ES5); the 5.0.x client is also ES5 but brings no size benefit (132 KB).

## Result (net10.0, on top of #685)

| File | Before | After |
|---|---|---|
| `drapo.js` | 1,010,027 | 929,482 |
| `drapo.min.js` | 487,027 | **454,648** (100,918 gzipped) |

## Verification
- `dotnet build Drapo.sln` Debug and Release.
- Full Selenium suite **356/356** against Debug and against a Production-environment Release WebDrapo (mangled `drapo.min.js` with the new client). The pipes are genuinely exercised: `PlumberExecuteAsyncTest` posts an expression that the server pushes back through the hub for the client to execute, and every page with the `__drapoUnitTest` hook waits for the hub connection and pipe registration before it starts.
- `MessageSendValueTest` flaked once before #687's fix was applied to this branch; with the fix, the full Debug run is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PoCkvgpwqmvxSX7bYCLrTX
