### PR TITLE
fix(692): skip pack scripts of components already active on the page

### DIFF
--- a/src/Middleware/Drapo/ts/DrapoPackHandler.ts
+++ b/src/Middleware/Drapo/ts/DrapoPackHandler.ts
@@ -79,40 +79,39 @@ class DrapoPackHandler {
     private async ProcessPackData(packName: string, packData: any): Promise<void> {
         if ((packData == null) || (packData.files == null))
             return;
+        const componentTags: { [url: string]: string } = await this.Application.Register.GetComponentTagsByFileUrl();
         const componentsActivated: string[] = [];
         // Process each file in the pack
         for (const file of packData.files) {
             if ((file.path == null) || (file.content == null))
                 continue;
             // Component assets already on the page (activated before the pack landed) are not appended again
-            const componentName: string = this.ExtractComponentNameFromPath(file.path);
-            const skipAssets: boolean = (componentName != null) && (await this.IsComponentAssetsLoaded(componentName, componentsActivated));
+            const tagName: string = componentTags[this.NormalizeFileUrl(file.path)];
+            const skipAssets: boolean = (tagName != null) && (this.IsComponentAssetsLoaded(tagName, componentsActivated));
             // Place the file content in the correct location
             await this.ProcessPackFile(file.path, file.content, skipAssets);
         }
     }
 
-    private async IsComponentAssetsLoaded(componentName: string, componentsActivated: string[]): Promise<boolean> {
+    private IsComponentAssetsLoaded(tagName: string, componentsActivated: string[]): boolean {
         // Components activated by this pack keep receiving their remaining files
-        if (componentsActivated.indexOf(componentName) !== -1)
+        if (componentsActivated.indexOf(tagName) !== -1)
             return (false);
-        const tagName: string = `d-${componentName}`;
         if (this.Application.Register.IsActiveComponent(tagName))
             return (true);
         // Mark as active before appending the first file so a concurrent activation does not load the files again
-        if (await this.Application.Register.IsRegisteredComponent(tagName))
-            this.Application.Register.MarkComponentAsActive(tagName);
-        componentsActivated.push(componentName);
+        this.Application.Register.MarkComponentAsActive(tagName);
+        componentsActivated.push(tagName);
         return (false);
     }
 
-    private ExtractComponentNameFromPath(filePath: string): string {
-        // Extract component name from paths like: "~/components/mycomponent/file.js"
-        const pathParts = filePath.split('/');
-        if (pathParts.length >= 3 && pathParts[1] === 'components') {
-            return pathParts[2];
-        }
-        return null;
+    private NormalizeFileUrl(filePath: string): string {
+        const queryIndex: number = filePath.indexOf('?');
+        if (queryIndex !== -1)
+            filePath = filePath.substring(0, queryIndex);
+        if (filePath.startsWith('~/'))
+            return (filePath);
+        return ('~/' + (filePath.startsWith('/') ? filePath.substring(1) : filePath));
     }
 
     private async ProcessPackFile(filePath: string, content: string, skipAssets: boolean): Promise<void> {

--- a/src/Middleware/Drapo/ts/DrapoPackHandler.ts
+++ b/src/Middleware/Drapo/ts/DrapoPackHandler.ts
@@ -79,23 +79,31 @@ class DrapoPackHandler {
     private async ProcessPackData(packName: string, packData: any): Promise<void> {
         if ((packData == null) || (packData.files == null))
             return;
-        const componentFiles: { [key: string]: any[] } = {};
+        const componentsActivated: string[] = [];
         // Process each file in the pack
         for (const file of packData.files) {
             if ((file.path == null) || (file.content == null))
                 continue;
-            // Check if this file belongs to a component
-            const componentName = this.ExtractComponentNameFromPath(file.path);
-            if (componentName != null) {
-                if (!componentFiles[componentName])
-                    componentFiles[componentName] = [];
-                componentFiles[componentName].push(file);
-            }
+            // Component assets already on the page (activated before the pack landed) are not appended again
+            const componentName: string = this.ExtractComponentNameFromPath(file.path);
+            const skipAssets: boolean = (componentName != null) && (await this.IsComponentAssetsLoaded(componentName, componentsActivated));
             // Place the file content in the correct location
-            await this.ProcessPackFile(file.path, file.content);
+            await this.ProcessPackFile(file.path, file.content, skipAssets);
         }
-        // Mark components as active if all their files were loaded
-        await this.MarkComponentsAsActive(componentFiles);
+    }
+
+    private async IsComponentAssetsLoaded(componentName: string, componentsActivated: string[]): Promise<boolean> {
+        // Components activated by this pack keep receiving their remaining files
+        if (componentsActivated.indexOf(componentName) !== -1)
+            return (false);
+        const tagName: string = `d-${componentName}`;
+        if (this.Application.Register.IsActiveComponent(tagName))
+            return (true);
+        // Mark as active before appending the first file so a concurrent activation does not load the files again
+        if (await this.Application.Register.IsRegisteredComponent(tagName))
+            this.Application.Register.MarkComponentAsActive(tagName);
+        componentsActivated.push(componentName);
+        return (false);
     }
 
     private ExtractComponentNameFromPath(filePath: string): string {
@@ -107,29 +115,18 @@ class DrapoPackHandler {
         return null;
     }
 
-    private async MarkComponentsAsActive(componentFiles: { [key: string]: any[] }): Promise<void> {
-        for (const componentName in componentFiles) {
-            const files = componentFiles[componentName];
-            // Check if component exists and mark it as active
-            if (await this.Application.Register.IsRegisteredComponent(`d-${componentName}`)) {
-                if (!this.Application.Register.IsActiveComponent(`d-${componentName}`)) {
-                    // Mark as active without loading files since we already loaded them from the pack
-                    this.Application.Register.MarkComponentAsActive(`d-${componentName}`);
-                }
-            }
-        }
-    }
-
-    private async ProcessPackFile(filePath: string, content: string): Promise<void> {
+    private async ProcessPackFile(filePath: string, content: string, skipAssets: boolean): Promise<void> {
         // Determine the file type and handle accordingly
         const extension = this.GetFileExtension(filePath).toLowerCase();
 
         if (extension === '.js') {
             // Load as JavaScript
-            await this.LoadPackScript(filePath, content);
+            if (!skipAssets)
+                await this.LoadPackScript(filePath, content);
         } else if (extension === '.css') {
             // Load as CSS
-            await this.LoadPackStyle(filePath, content);
+            if (!skipAssets)
+                await this.LoadPackStyle(filePath, content);
         } else if (extension === '.html') {
             // Load as HTML template - could be stored for later use
             await this.LoadPackTemplate(filePath, content);

--- a/src/Middleware/Drapo/ts/DrapoRegister.ts
+++ b/src/Middleware/Drapo/ts/DrapoRegister.ts
@@ -1,4 +1,4 @@
-class DrapoRegister {
+﻿class DrapoRegister {
     //Field
     private _application: DrapoApplication;
     private _components: string[] = [];
@@ -129,9 +129,24 @@ class DrapoRegister {
         return (this.GetCacheData(index));
     }
 
+    public async GetComponentTagsByFileUrl(): Promise<{ [url: string]: string }> {
+        const tags: { [url: string]: string } = {};
+        const components: any[] = await this.Application.Config.GetSector("Components");
+        if (components == null)
+            return (tags);
+        for (const component of components)
+            for (const file of component.Files)
+                tags[this.GetComponentFileRelativeUrl(component, file)] = component.Tag;
+        return (tags);
+    }
+
+    private GetComponentFileRelativeUrl(component: any, file: any): string {
+        return (file.ResourceType === 1 ? file.Path : '~/components/' + component.Name + '/' + file.Name);
+    }
+
     private async GetComponentFileUrl(component: any, file: any) : Promise<string>
     {
-        let url: string = file.ResourceType === 1 ? file.Path : '~/components/' + component.Name + '/' + file.Name;
+        let url: string = this.GetComponentFileRelativeUrl(component, file);
         url += await this.Application.Server.AppendUrlQueryStringCacheStatic(url);
         return (url);
     }

--- a/src/Test/WebDrapo.Test/Pages/PackComponentActive.Test.html
+++ b/src/Test/WebDrapo.Test/Pages/PackComponentActive.Test.html
@@ -1,0 +1,85 @@
+﻿<!DOCTYPE html><html><head>
+    <script src="/drapo.js"></script>
+    <script>
+        window.addEventListener('error', function (e) { document.getElementById('pageErrors').textContent += e.message + ';'; });
+    </script>
+    <title>Pack - Component Active</title>
+<link href="" rel="stylesheet" /><script src=""></script><style type="text/css" data-pack-file="~/testpack/test.css">/* Test CSS file for pack */
+.pack-test-style {
+    color: blue;
+    font-weight: bold;
+    background-color: #f0f8ff;
+    padding: 10px;
+    border: 2px solid #0066cc;
+    border-radius: 5px;
+}
+
+.test-component {
+    border: 2px solid #4CAF50;
+    padding: 15px;
+    margin: 10px 0;
+    border-radius: 8px;
+    background-color: #f9f9f9;
+}
+
+.test-component .counter {
+    font-size: 24px;
+    font-weight: bold;
+    color: #2196F3;
+}
+
+.test-component button {
+    background-color: #4CAF50;
+    color: white;
+    padding: 8px 16px;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    margin: 5px;
+}
+
+.test-component button:hover {
+    background-color: #45a049;
+}
+
+.pack-loaded {
+    background-color: lightgreen;
+    padding: 5px;
+}</style></head>
+<body>
+    <span>Pack - Component Active</span>
+    <br>
+    <span>Page errors: </span><span id="pageErrors"></span>
+    <br>
+    <div d-datakey="packData" d-datatype="object" d-datavalue="{&quot;name&quot;: &quot;Drapo&quot;, &quot;message&quot;: &quot;Pack not loaded&quot;}"></div>
+    <div dc-model="{{packData.name}}">
+    <span>packData.name</span>
+    <span>Drapo</span>
+</div>
+    <br>
+    <span d-model="{{packData.message}}">Loaded</span>
+    <br>
+    <input type="button" driverunittest="click" value="Load Pack" d-on-click="LoadPack(testpack);UpdateDataField(packData,message,Loaded);UpdateSector(componenttest,~/testpack/component-test-page.html)">
+    <div d-sector="@"><div d-sector="@">
+        <div d-datakey="packComponent" d-datatype="object" d-datavalue="{&quot;Value&quot;: 1}"></div>
+        <h2>Component Test Page</h2>
+        <p>This page demonstrates using a component that was loaded from a pack.</p>
+        <div dc-model="{{packComponent.Value}}">
+    <span>packComponent.Value</span>
+    <span>1</span>
+</div>
+    </div>
+    <div style="margin-top: 20px; padding: 10px; background-color: #e8f5e8; border-radius: 5px;">
+        <p><strong>Success!</strong> If you can see the checkbox component above, it means:</p>
+        <ul>
+            <li>✅ The pack was loaded successfully</li>
+            <li>✅ The component files were processed and cached</li>
+            <li>✅ The component was marked as active</li>
+            <li>✅ No duplicate loading occurred</li>
+        </ul>
+    </div>
+
+</div>
+
+
+</body></html>

--- a/src/Test/WebDrapo.Test/ReleaseTest.cs
+++ b/src/Test/WebDrapo.Test/ReleaseTest.cs
@@ -1849,6 +1849,11 @@ namespace WebDrapo.Test
             ValidatePage("ParseDate");
         }
         [TestCase]
+        public void PackComponentActiveTest()
+        {
+            ValidatePage("PackComponentActive");
+        }
+        [TestCase]
         public void ParseNumberTest()
         {
             ValidatePage("ParseNumber");

--- a/src/Web/WebDrapo/wwwroot/DrapoPages/PackComponentActive.html
+++ b/src/Web/WebDrapo/wwwroot/DrapoPages/PackComponentActive.html
@@ -1,0 +1,23 @@
+﻿<!DOCTYPE html>
+<html>
+<head>
+    <script src="/drapo.js"></script>
+    <script>
+        window.addEventListener('error', function (e) { document.getElementById('pageErrors').textContent += e.message + ';'; });
+    </script>
+    <title>Pack - Component Active</title>
+</head>
+<body>
+    <span>Pack - Component Active</span>
+    <br />
+    <span>Page errors: </span><span id="pageErrors"></span>
+    <br />
+    <div d-dataKey="packData" d-dataType="object" d-dataValue='{"name": "Drapo", "message": "Pack not loaded"}'></div>
+    <d-labelcontext dc-model="{{packData.name}}"></d-labelcontext>
+    <br />
+    <span d-model="{{packData.message}}"></span>
+    <br />
+    <input type="button" driverunittest="click" value="Load Pack" d-on-click="LoadPack(testpack);UpdateDataField(packData,message,Loaded);UpdateSector(componenttest,~/testpack/component-test-page.html)" />
+    <div d-sector="componenttest"></div>
+</body>
+</html>


### PR DESCRIPTION
Fixes #692

## Problem

When a component is rendered while `LoadPack(<pack>)` is still downloading, Drapo activates it the normal way (`<script src="~/components/<x>/<x>.js">`). When the pack lands, `ProcessPackData` appended every script in the pack — including the ones for components already active on the page — so the same script executed twice. With ES2015+ component output (`class X { … }` at script top level) the second execution throws:

```
SyntaxError: Failed to execute 'appendChild' on 'Node': Identifier 'X' has already been declared
```

It surfaces as an unhandled page error on every page load of any consumer that builds a components pack (downstream report with the five affected components: t6-enterprise/powerplanning#9071). Excluding the components from the pack is not a fix: a component rendered *after* the pack landed then has no script at all.

## Fix (`DrapoPackHandler.ts`)

- `ProcessPackData` resolves the owning component of every pack file through the registered components' file URLs (new `DrapoRegister.GetComponentTagsByFileUrl`, built from the same URL the register uses to load a file individually — so nested layouts such as `~/components/dashboard/parts/<x>/part<x>.js` registered as `d-part<x>` are recognised, not only `~/components/<x>/<x>.js`). If that component is already active, the file's `.js`/`.css` are skipped (they are already on the page); its `.html` view is still cached.
- A component that is *not* yet active is marked active **before** its first file is appended (previously marking happened after the whole pack was processed), so a concurrent `ActivateComponent` cannot load the files a second time either. `MarkComponentsAsActive` is folded into this per-component check.
- Unregistered component directories in a pack keep their previous behaviour (files appended, nothing marked).

Both orderings of the race are covered: component first → pack skips it; pack first → component handler sees it active and skips the individual load (existing behaviour, re-verified on `PackTest.html`).

Verified downstream on PowerPlanning (non-Debug, `components` pack of 3.4 MB, home dashboard + a form): with the published 2026.9.7.11 the home page raises 8 page errors (`SDK`, `Shortcut`, `ContextHelp`, `Tai` from the pack re-append, plus `PartExplorer`, `PartWorkflowInstances`, `PartCMS`, `PartWorkflowNotes` from the reverse ordering); with this branch packed locally, 0 — the race still happens (22 component scripts fetched individually before the pack landed, 165 appended from the pack) but nothing is appended twice.

## Test

New DrapoPages test `PackComponentActive` (registered in `ReleaseTest.cs`): renders `<d-labelcontext>` (compiled to `class LabelContext`, included in `testpack`), then the harness clicks **Load Pack** → `LoadPack(testpack)` → updates a field → loads a sector that renders a second `<d-labelcontext>`. The page mirrors `window` `error` events into a `#pageErrors` span, so the snapshot asserts there was **no** page error and that the component rendered after the pack still works. Before the fix the span reads `Uncaught SyntaxError: … Identifier 'LabelContext' has already been declared;` (reproduced on the unfixed runtime).

## Gates

- `npm run lint` — zero errors
- `dotnet build Drapo.sln` — 0 errors
- Full `WebDrapo.Test` suite against a local WebDrapo (`Test.Debug.runsettings`): **367 passed, 0 failed** (re-run on the final commit: 2 m 13 s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhpQPSTPfAtSTKbh22rukr
